### PR TITLE
Eliminate unsound conversion from const reference to mutable slice

### DIFF
--- a/include/cxx_aoflagger.h
+++ b/include/cxx_aoflagger.h
@@ -14,7 +14,8 @@ size_t Width() const;
 size_t Height() const;
 size_t ImageCount() const;
 size_t HorizontalStride() const;
-rust::Slice<float> ImageBuffer(size_t imgIndex) const;
+rust::Slice<const float> ImageBuffer(size_t imgIndex) const;
+rust::Slice<float> ImageBufferMut(size_t imgIndex);
 private:
 CxxImageSet();
 CxxImageSet(ImageSet impl);
@@ -28,7 +29,8 @@ public:
 size_t Width() const;
 size_t Height() const;
 size_t HorizontalStride() const;
-rust::Slice<bool> Buffer() const;
+rust::Slice<const bool> Buffer() const;
+rust::Slice<bool> BufferMut();
 private:
 CxxFlagMask();
 CxxFlagMask(FlagMask impl);

--- a/src/cxx_aoflagger.cc
+++ b/src/cxx_aoflagger.cc
@@ -26,7 +26,11 @@ size_t CxxImageSet::ImageCount() const {
 size_t CxxImageSet::HorizontalStride() const {
 	return this->pImpl->HorizontalStride();
 }
-rust::Slice<float> CxxImageSet::ImageBuffer(size_t imgIndex) const {
+rust::Slice<const float> CxxImageSet::ImageBuffer(size_t imgIndex) const {
+	rust::Slice<const float> slice{this->pImpl->ImageBuffer(imgIndex), Height() * HorizontalStride()};
+	return slice;
+}
+rust::Slice<float> CxxImageSet::ImageBufferMut(size_t imgIndex) {
 	rust::Slice<float> slice{this->pImpl->ImageBuffer(imgIndex), Height() * HorizontalStride()};
 	return slice;
 }
@@ -44,8 +48,12 @@ size_t CxxFlagMask::Height() const {
 size_t CxxFlagMask::HorizontalStride() const {
 	return this->pImpl->HorizontalStride();
 }
-rust::Slice<bool> CxxFlagMask::Buffer() const {
-	rust::Slice<bool> slice{(bool *)(this->pImpl->Buffer()), Height() * HorizontalStride()};
+rust::Slice<const bool> CxxFlagMask::Buffer() const {
+	rust::Slice<const bool> slice{this->pImpl->Buffer(), Height() * HorizontalStride()};
+	return slice;
+}
+rust::Slice<bool> CxxFlagMask::BufferMut() {
+	rust::Slice<bool> slice{this->pImpl->Buffer(), Height() * HorizontalStride()};
 	return slice;
 }
 


### PR DESCRIPTION
Clippy caught that these were unsound, hence the strongly worded deny-by-default lint that had to get suppressed in the two signatures below.

https://github.com/MWATelescope/Birli/blob/cc605a0d47fec327f00b6e8c7823262f6c9a67d4/src/cxx_aoflagger.rs#L21-L23

https://github.com/MWATelescope/Birli/blob/cc605a0d47fec327f00b6e8c7823262f6c9a67d4/src/cxx_aoflagger.rs#L29-L31

<br>

https://rust-lang.github.io/rust-clippy/master/#mut_from_ref

> **Why is this bad**
> This is trivially unsound, as one can create two mutable references from the same (immutable!) source.