### PR TITLE
V0.7.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,28 +14,19 @@ name: Generate Coverage report
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    container: mwatelescope/marlu:latest
+    container: mwatelescope/birli:latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - uses: taiki-e/github-actions/install-rust@main
-        with:
-          toolchain: nightly-2022-05-20
-          component: llvm-tools-preview
-
-      - name: install cargo-llvm-cov
-        run: cargo +nightly-2022-05-20 install cargo-llvm-cov
-
       - name: Generate test lcov coverage into coverage/ dir
         run: |
-          export PATH="${HOME}/.cargo/bin:${PATH}"
           mkdir -p coverage
-          cargo +nightly-2022-05-20 llvm-cov --all --lcov --output-path coverage/coverage.lcov
+          /opt/cargo/bin/cargo llvm-cov --all --lcov --output-path coverage/coverage.lcov
           # this uses the result of the previous run to generate a text summary
-          cargo +nightly-2022-05-20 llvm-cov --no-run
+          /opt/cargo/bin/cargo llvm-cov --no-run
 
       - name: Upload reports to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,11 +4,10 @@
 on:
   push:
     tags-ignore:
-      - '**'
+      - "**"
     branches:
-    - '**'
+      - "**"
   pull_request:
-
 
 name: Generate Coverage report
 
@@ -24,19 +23,19 @@ jobs:
 
       - uses: taiki-e/github-actions/install-rust@main
         with:
-          toolchain: nightly-2022-01-14
+          toolchain: nightly-2022-05-20
           component: llvm-tools-preview
 
       - name: install cargo-llvm-cov
-        run: cargo +nightly-2022-01-14 install cargo-llvm-cov
+        run: cargo +nightly-2022-05-20 install cargo-llvm-cov
 
       - name: Generate test lcov coverage into coverage/ dir
         run: |
           export PATH="${HOME}/.cargo/bin:${PATH}"
           mkdir -p coverage
-          cargo +nightly-2022-01-14 llvm-cov --all --lcov --output-path coverage/coverage.lcov
+          cargo +nightly-2022-05-20 llvm-cov --all --lcov --output-path coverage/coverage.lcov
           # this uses the result of the previous run to generate a text summary
-          cargo +nightly-2022-01-14 llvm-cov --no-run
+          cargo +nightly-2022-05-20 llvm-cov --no-run
 
       - name: Upload reports to codecov.io
         uses: codecov/codecov-action@v2

--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -12,9 +12,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: cargo check
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: /opt/cargo/bin/cargo check
+      - run: /opt/cargo/bin/cargo fmt --all -- --check
+      - run: /opt/cargo/bin/cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: Docker Tests
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: cargo test --release
+      - run: /opt/cargo/bin/cargo test --release
 
   test_no_default:
     name: Docker Tests - No Default
@@ -36,4 +36,4 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: cargo test --no-default-features --release
+      - run: /opt/cargo/bin/cargo test --no-default-features --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,15 +111,15 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.4.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -163,7 +163,7 @@ dependencies = [
  "built",
  "byteorder",
  "cfg-if",
- "clap 3.1.8",
+ "clap 3.2.6",
  "criterion",
  "crossbeam-channel",
  "crossbeam-utils",
@@ -181,6 +181,7 @@ dependencies = [
  "ndarray",
  "prettytable-rs",
  "regex",
+ "shlex",
  "tempfile",
  "thiserror",
 ]
@@ -227,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -239,9 +240,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cargo-lock"
-version = "7.0.1"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb04b88bd5b2036e30704f95c6ee16f3b5ca3b4ca307da2889d9006648e5c88"
+checksum = "6c408da54db4c50d4693f7e649c299bc9de9c23ead86249e5368830bb32a734b"
 dependencies = [
  "semver",
  "serde",
@@ -260,11 +261,11 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.21.0"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485ede05a56152367a6ec586a7425b475d6c3d3838581ff651d2a6e3730a62ef"
+checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
- "clap 3.1.8",
+ "clap 3.2.6",
  "heck",
  "indexmap",
  "log",
@@ -316,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
+checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
 dependencies = [
  "glob",
  "libc",
@@ -342,18 +343,27 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "9f1fe12880bae935d142c8702d500c63a4e8634b6c3c57ad72bf978fc7b6249a"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -443,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -464,26 +474,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -510,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2295fe8865279f404147e9b2328e5af0ad11a2c016e58c13acfd48a07d8a55"
+checksum = "f632f8f2088ccabd3a112eb2037a7cf0520ed5240189f2b1b8185f65340b66a1"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -522,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aaaa055d4908326f1b4524b23ae53758019b806c0c4f382ea240982e9766b26"
+checksum = "e42d6327fe79cc1a0380dbc346d839d38bf4712f91aed7f2a502ed834a7b1791"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -537,15 +547,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a670224c6686471df12560a0b97a08145082e70bd38e2b0b5383b79e46c3da7"
+checksum = "7132db09c11d09a90fdc7d5d8b0a3d5b6bb08c710850037969a01105c7b104d9"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b700096ca0dece28d9535fdb17ab784a8ae155d7f29d39c273643e6292c9620"
+checksum = "9669b856f798cc6c2a22d0183eb310cb2587bc6aca4ecfdb7ba07369869e38cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -554,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -564,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.12.4"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -578,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.4"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
  "darling_core",
  "quote",
@@ -589,18 +599,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d918e7dabe374a51dae0f29d818fece3b218b8b4eabec3bc4d42c537e7ed8f"
+checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f712c2d4e52d5fcae53584e461dcb92fb2202e144ebf83ab0ba4360d18b767c7"
+checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -610,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2ac71b4a9a590dde6cee3ca4687aca5e7ce06f4ee297c5a959de5f1e42b2e"
+checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
  "syn",
@@ -709,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -741,14 +751,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
- "cfg-if",
  "crc32fast",
- "libc",
- "miniz_oxide 0.5.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -820,9 +828,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heck"
@@ -841,10 +849,11 @@ dependencies = [
 
 [[package]]
 name = "hifitime"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ffba03889a8751f0d86cbae437d74a2c60f22ec723b7fd2443302d8649a48c"
+checksum = "27533983a899584820e14af1f5939cf8b0e6ae4a69a888d7cb825e0e67b3f051"
 dependencies = [
+ "libm",
  "regex",
  "serde",
  "serde_derive",
@@ -875,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -922,9 +931,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jobserver"
@@ -937,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -958,18 +967,18 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical"
-version = "6.1.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd3e434c16f0164124ade12dcdee324fcc3dafb1cad0c7f1d8c2451a1aa6886"
+checksum = "c7aefb36fd43fef7003334742cbf77b243fcd36418a1d1bdd480d613a67968f6"
 dependencies = [
  "lexical-core",
 ]
 
 [[package]]
 name = "lexical-core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92912c4af2e7d9075be3e5e3122c4d7263855fa6cce34fbece4dd08e5884624d"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
 dependencies = [
  "lexical-parse-float",
  "lexical-parse-integer",
@@ -980,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "lexical-parse-float"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f518eed87c3be6debe6d26b855c97358d8a11bf05acec137e5f53080f5ad2dd8"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
 dependencies = [
  "lexical-parse-integer",
  "lexical-util",
@@ -991,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "lexical-parse-integer"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc852ec67c6538bbb2b9911116a385b24510e879a69ab516e6a151b15a79168"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
 dependencies = [
  "lexical-util",
  "static_assertions",
@@ -1001,18 +1010,18 @@ dependencies = [
 
 [[package]]
 name = "lexical-util"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a9d52c5c4e62fa2cdc2cb6c694a39ae1382d9c2a17a466f18e272a0930eb1"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
 dependencies = [
  "static_assertions",
 ]
 
 [[package]]
 name = "lexical-write-float"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89ec1d062e481210c309b672f73a0567b7855f21e7d2fae636df44d12e97f9"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
 dependencies = [
  "lexical-util",
  "lexical-write-integer",
@@ -1021,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "lexical-write-integer"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094060bd2a7c2ff3a16d5304a6ae82727cb3cc9d1c70f813cc73f744c319337e"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
 dependencies = [
  "lexical-util",
  "static_assertions",
@@ -1031,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgit2-sys"
@@ -1058,10 +1067,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.5"
+name = "libm"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
  "libc",
@@ -1080,17 +1095,17 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "marlu"
-version = "0.6.1"
-source = "git+https://github.com/MWATelescope/Marlu.git?branch=v0.7.0#4f37e06424c0c116b100e35ff7e5aebf7bb82081"
+version = "0.7.0"
+source = "git+https://github.com/MWATelescope/Marlu.git#5b5a0d77a9426f0e7a49b540c1a747a0af721a62"
 dependencies = [
  "approx",
  "cfg-if",
@@ -1132,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -1153,28 +1168,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mwalib"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4adb7a05f3ee06661d37396a80fc2061fc4dabef0517fed1de550f3cd05ccc"
+checksum = "ffcfc24d697d5a094126b8e9cbac890e483dbc7e42c02f074aeccc65c4542263"
 dependencies = [
  "built",
  "cbindgen",
@@ -1218,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
 ]
@@ -1238,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1248,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -1273,18 +1278,18 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "oorandom"
@@ -1294,12 +1299,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "peeking_take_while"
@@ -1363,18 +1365,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -1387,9 +1389,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1399,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1437,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1454,9 +1456,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -1541,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "same-file"
@@ -1568,18 +1570,18 @@ checksum = "96311ef4a16462c757bb6a39152c40f58f31cd2602a40fceb937e2bc34e6cbab"
 
 [[package]]
 name = "semver"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
@@ -1596,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1607,11 +1609,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -1642,13 +1644,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1735,18 +1737,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1776,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1791,18 +1793,24 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
@@ -1821,9 +1829,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "url"
@@ -1874,9 +1882,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1884,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1899,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1909,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1922,15 +1930,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1980,9 +1988,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xattr"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "birli"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "aoflagger_sys",
  "approx",
@@ -1105,7 +1105,8 @@ dependencies = [
 [[package]]
 name = "marlu"
 version = "0.7.0"
-source = "git+https://github.com/MWATelescope/Marlu.git#5b5a0d77a9426f0e7a49b540c1a747a0af721a62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5624a18fc8cef0d3192003ccb215a9beeca3edb231ef0d8bac131e305ffa767a"
 dependencies = [
  "approx",
  "cfg-if",
@@ -1814,9 +1815,9 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "81dee68f85cab8cf68dec42158baf3a79a1cdc065a8b103025965d6ccb7f6cbd"
 dependencies = [
  "tinyvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
@@ -260,11 +260,11 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e3973b165dc0f435831a9e426de67e894de532754ff7a3f307c03ee5dec7dc"
+checksum = "485ede05a56152367a6ec586a7425b475d6c3d3838581ff651d2a6e3730a62ef"
 dependencies = [
- "clap 2.34.0",
+ "clap 3.1.8",
  "heck",
  "indexmap",
  "log",
@@ -668,9 +668,9 @@ checksum = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
 
 [[package]]
 name = "erfa-sys"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1233c4552f41a232c35c723063b2666a10d0f528c3db2a6a1fac559674f3b606"
+checksum = "e8e482f94197feed1ce45fbb8c38c8c6449fd6ac00daccf0f5fe7ccafc06717a"
 dependencies = [
  "autotools",
  "pkg-config",
@@ -715,7 +715,7 @@ checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.11",
+ "redox_syscall 0.2.13",
  "winapi",
 ]
 
@@ -741,14 +741,14 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
 dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.5.1",
 ]
 
 [[package]]
@@ -785,17 +785,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -837,12 +826,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -855,12 +841,10 @@ dependencies = [
 
 [[package]]
 name = "hifitime"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd06a5be930b7e56b7badc6832d6fcf3dac0bb29c2422f497a02d924aa7151ac"
+checksum = "62ffba03889a8751f0d86cbae437d74a2c60f22ec723b7fd2443302d8649a48c"
 dependencies = [
- "rand",
- "rand_distr",
  "regex",
  "serde",
  "serde_derive",
@@ -891,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -953,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1047,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "libgit2-sys"
@@ -1072,12 +1056,6 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libz-sys"
@@ -1112,8 +1090,7 @@ dependencies = [
 [[package]]
 name = "marlu"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a64ec6379ed12090bd240dfc59aede2a6f1cb2b9777dff220f654e600918afa"
+source = "git+https://github.com/MWATelescope/Marlu.git?branch=v0.7.0#4f37e06424c0c116b100e35ff7e5aebf7bb82081"
 dependencies = [
  "approx",
  "cfg-if",
@@ -1185,10 +1162,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "mwalib"
-version = "0.13.0"
+name = "miniz_oxide"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7c4832b4c86376fed65bcc73e1c7ff801dedd7ea4794a4baf5db991531a9b5"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mwalib"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4adb7a05f3ee06661d37396a80fc2061fc4dabef0517fed1de550f3cd05ccc"
 dependencies = [
  "built",
  "cbindgen",
@@ -1267,7 +1253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1330,9 +1315,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
@@ -1363,12 +1348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
 name = "prettytable-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,60 +1363,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom 0.2.5",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand",
 ]
 
 [[package]]
@@ -1448,9 +1387,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1460,14 +1399,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -1479,9 +1417,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -1492,7 +1430,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom 0.1.16",
+ "getrandom",
  "redox_syscall 0.1.57",
  "rust-argon2",
 ]
@@ -1630,9 +1568,9 @@ checksum = "96311ef4a16462c757bb6a39152c40f58f31cd2602a40fceb937e2bc34e6cbab"
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 dependencies = [
  "serde",
 ]
@@ -1704,9 +1642,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1745,7 +1683,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall 0.2.11",
+ "redox_syscall 0.2.13",
  "remove_dir_all",
  "winapi",
 ]
@@ -1817,11 +1755,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1873,12 +1812,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -1935,15 +1868,15 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1951,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1966,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1976,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1989,15 +1922,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "birli"
 description = "A preprocessing pipeline for the Murchison Widefield Array"
-version = "0.6.4"
+version = "0.7.0"
 readme = "README.md"
 homepage = "https://github.com/MWATelescope/Birli"
 repository = "https://github.com/MWATelescope/Birli"
@@ -72,5 +72,5 @@ opt-level = 3
 
 [patch.crates-io]
 # marlu = { path = "../Marlu" }
-marlu = { git = "https://github.com/MWATelescope/Marlu.git" }
+# marlu = { git = "https://github.com/MWATelescope/Marlu.git" }
 # mwalib = { git = "https://github.com/MWATelescope/mwalib", branch = "v0.14.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,5 @@ opt-level = 3
 
 [patch.crates-io]
 # marlu = { path = "../Marlu" }
-# marlu = { git = "https://github.com/MWATelescope/Marlu.git", branch = "..." }
+marlu = { git = "https://github.com/MWATelescope/Marlu.git", branch = "v0.7.0" }
+# mwalib = { git = "https://github.com/MWATelescope/mwalib", branch = "v0.14.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
     "Luke A. Williams <luke.a.williams@curtin.edu.au>",
 ]
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 license = "MPL-2.0"
 keywords = ["radioastronomy", "mwa", "astronomy", "aoflagger", "cotter"]
 categories = ["science", "parsing"]
@@ -40,10 +40,11 @@ indicatif = { version = "0.16", features = ["rayon"] }
 itertools = "0.10"
 lazy_static = "1.4.*"
 log = "0.4"
-marlu = "0.6.1"
+marlu = "0.7.0"
 prettytable-rs = "0.8.0"
 regex = "1.4"
 thiserror = "1.0"
+shlex = "1.1.0"
 
 [dev-dependencies]
 approx = { version = "0.5.*", features = ["num-complex"] }
@@ -71,5 +72,5 @@ opt-level = 3
 
 [patch.crates-io]
 # marlu = { path = "../Marlu" }
-marlu = { git = "https://github.com/MWATelescope/Marlu.git", branch = "v0.7.0" }
+marlu = { git = "https://github.com/MWATelescope/Marlu.git" }
 # mwalib = { git = "https://github.com/MWATelescope/mwalib", branch = "v0.14.0" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,27 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG DEBUG
 RUN apt-get update \
     && apt-get install -y \
-        aoflagger-dev \
-        build-essential \
-        clang \
-        curl \
-        git \
-        jq \
-        lcov \
-        libcfitsio-dev \
-        liberfa-dev \
-        libssl-dev \
-        pkg-config \
-        unzip \
-        zip \
-        automake \
-        libtool
+    aoflagger-dev \
+    build-essential \
+    clang \
+    curl \
+    git \
+    jq \
+    lcov \
+    libcfitsio-dev \
+    liberfa-dev \
+    libssl-dev \
+    pkg-config \
+    unzip \
+    zip \
+    automake \
+    libtool
 
 RUN test -z "$DEBUG" || ( \
-        apt-get install -y vim gdb \
+    apt-get install -y vim gdb \
     )
 RUN apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -31,8 +31,12 @@ RUN mkdir -m755 /opt/rust /opt/cargo
 ENV RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/cargo PATH=/opt/cargo/bin:$PATH
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
-# Get cargo make
-RUN cargo install --force cargo-make
+# set minimal rust version here to use a newer stable version
+ARG CACHEBUST=1.61
+# install latest stable rust toolchian, with llvm-tools-preview (for coverage)
+RUN rustup toolchain install stable --component llvm-tools-preview
+# Get cargo make, llvm-cov
+RUN /opt/cargo/bin/cargo install --force cargo-make cargo-llvm-cov
 
 ADD . /app
 WORKDIR /app
@@ -40,9 +44,5 @@ WORKDIR /app
 RUN cargo clean \
     && cargo install --path . --features aoflagger --locked $(test -z "$DEBUG" || echo "--debug") \
     && cargo clean
-
-# setup the toolchain used for coverage analysis
-RUN rustup toolchain install nightly-2022-01-14 --component llvm-tools-preview --profile minimal \
-    && cargo +nightly-2022-01-14 install --force cargo-llvm-cov
 
 ENTRYPOINT [ "/opt/cargo/bin/birli" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get update \
         libssl-dev \
         pkg-config \
         unzip \
-        zip
+        zip \
+        automake \
+        libtool
 
 RUN test -z "$DEBUG" || ( \
         apt-get install -y vim gdb \

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,19 @@
 <!-- markdownlint-disable=MD025 -->
 
+# Version 0.7.0 (unreleased)
+
+- ⚡ performance:
+  - Fix unnecessary allocation for smaller visibility chunks to improve memory performance
+  - better uvfits performance from marlu 0.7.0
+- 🙏 quality of life:
+  - write `history` metadata in ms and uvfits
+- 🏗 api changes:
+  - use array views for flagging
+- ➕ dependencies:
+  - use Marlu 0.7.0
+  - use rust version 1.60
+  - use shlex for command line argument escaping
+
 # Version 0.6.4 (2022-05-04)
 
 - ✨ new features:

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -36,7 +36,7 @@ fn get_context_1196175296() -> CorrelatorContext {
         .filter_map(Result::ok)
         .map(|path| path.to_str().unwrap().to_owned())
         .collect();
-    CorrelatorContext::new(&metafits_path, &gpufits_files).unwrap()
+    CorrelatorContext::new(metafits_path, &gpufits_files).unwrap()
 }
 
 fn bench_uvfits_output_1196175296_none(crt: &mut Criterion) {

--- a/benches/expensive_benches.rs
+++ b/benches/expensive_benches.rs
@@ -118,7 +118,7 @@ fn bench_correct_cable_lengths_mwax_half_1247842824(crt: &mut Criterion) {
         bch.iter(|| {
             correct_cable_lengths(
                 black_box(&corr_ctx),
-                black_box(&mut jones_array),
+                black_box(jones_array.view_mut()),
                 black_box(&vis_sel.coarse_chan_range),
                 false,
             )
@@ -145,7 +145,7 @@ fn bench_correct_cable_lengths_ord_half_1196175296(crt: &mut Criterion) {
         bch.iter(|| {
             correct_cable_lengths(
                 black_box(&corr_ctx),
-                black_box(&mut jones_array),
+                black_box(jones_array.view_mut()),
                 black_box(&vis_sel.coarse_chan_range),
                 false,
             )
@@ -172,7 +172,7 @@ fn bench_correct_geometry_mwax_half_1247842824(crt: &mut Criterion) {
         bch.iter(|| {
             correct_geometry(
                 black_box(&corr_ctx),
-                black_box(&mut jones_array),
+                black_box(jones_array.view_mut()),
                 black_box(&vis_sel.timestep_range),
                 black_box(&vis_sel.coarse_chan_range),
                 None,
@@ -202,7 +202,7 @@ fn bench_correct_geometry_ord_half_1196175296(crt: &mut Criterion) {
         bch.iter(|| {
             correct_geometry(
                 black_box(&corr_ctx),
-                black_box(&mut jones_array),
+                black_box(jones_array.view_mut()),
                 black_box(&vis_sel.timestep_range),
                 black_box(&vis_sel.coarse_chan_range),
                 None,

--- a/benches/expensive_benches.rs
+++ b/benches/expensive_benches.rs
@@ -34,7 +34,7 @@ fn get_context_mwax_half_1247842824() -> CorrelatorContext {
         .filter_map(Result::ok)
         .map(|path| path.to_str().unwrap().to_owned())
         .collect();
-    CorrelatorContext::new(&metafits_path, &gpufits_files).unwrap()
+    CorrelatorContext::new(metafits_path, &gpufits_files).unwrap()
 }
 
 fn get_context_ord_half_1196175296() -> CorrelatorContext {
@@ -56,7 +56,7 @@ fn get_context_ord_half_1196175296() -> CorrelatorContext {
         .filter_map(Result::ok)
         .map(|path| path.to_str().unwrap().to_owned())
         .collect();
-    CorrelatorContext::new(&metafits_path, &gpufits_files).unwrap()
+    CorrelatorContext::new(metafits_path, &gpufits_files).unwrap()
 }
 
 fn bench_read_mwalib_mwax_half_1247842824(crt: &mut Criterion) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,11 +9,11 @@ use crate::{
             COTTER_MWA_HEIGHT_METRES, COTTER_MWA_LATITUDE_RADIANS, COTTER_MWA_LONGITUDE_RADIANS,
         },
         hifitime::Epoch,
-        io::{ms::MeasurementSetWriter, uvfits::UvfitsWriter, VisWritable},
+        io::{error::BadArrayShape, ms::MeasurementSetWriter, uvfits::UvfitsWriter, VisWritable},
         mwalib,
         ndarray::s,
         precession::{precess_time, PrecessionInfo},
-        LatLngHeight, RADec,
+        History, Jones, LatLngHeight, MwaObsContext, ObsContext, RADec, VisContext,
     },
     passband_gains::{PFB_COTTER_2014_10KHZ, PFB_JAKE_2022_200HZ},
     with_increment_duration, Axis, Complex, FlagFileSet, PreprocessContext, VisSelection,
@@ -22,7 +22,6 @@ use cfg_if::cfg_if;
 use clap::{arg, command, ErrorKind::ArgumentNotFound, PossibleValue, ValueHint::FilePath};
 use itertools::{izip, Itertools};
 use log::{debug, info, trace, warn};
-use marlu::{io::error::BadArrayShape, Jones, MwaObsContext, ObsContext, VisContext};
 use mwalib::{CorrelatorContext, GeometricDelaysApplied};
 use prettytable::{cell, format as prettyformat, row, table};
 use std::{
@@ -39,6 +38,9 @@ cfg_if! {
         use aoflagger_sys::{cxx_aoflagger_new};
     }
 }
+
+const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 
 /// Args for preprocessing a correlator context.
 pub struct BirliContext {
@@ -118,12 +120,7 @@ fn time_details(
 
 impl Display for BirliContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(
-            f,
-            "{} version {}",
-            env!("CARGO_PKG_NAME"),
-            env!("CARGO_PKG_VERSION"),
-        )?;
+        writeln!(f, "{} version {}", PKG_NAME, PKG_VERSION,)?;
 
         fmt_build_info(f)?;
 
@@ -1324,6 +1321,15 @@ impl BirliContext {
             None
         };
 
+        let args_strings = env::args().collect_vec();
+        let cmd_line = shlex::join(args_strings.iter().map(String::as_str));
+        let application = format!("{} {}", PKG_NAME, PKG_VERSION);
+        let message = prep_ctx.as_comment();
+        let history = History {
+            cmd_line: Some(&cmd_line),
+            application: Some(&application),
+            message: Some(&message),
+        };
         let mut uvfits_writer = io_ctx.uvfits_out.map(|uvfits_out| {
             with_increment_duration!(durations, "init", {
                 UvfitsWriter::from_marlu(
@@ -1332,6 +1338,7 @@ impl BirliContext {
                     Some(obs_ctx.array_pos),
                     obs_ctx.phase_centre,
                     obs_ctx.name.as_deref(),
+                    Some(&history),
                 )
                 .expect("unable to initialize uvfits writer")
             })
@@ -1341,7 +1348,13 @@ impl BirliContext {
                 MeasurementSetWriter::new(ms_out, obs_ctx.phase_centre, Some(obs_ctx.array_pos));
             with_increment_duration!(durations, "init", {
                 writer
-                    .initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, &vis_sel.coarse_chan_range)
+                    .initialize_mwa(
+                        &vis_ctx,
+                        &obs_ctx,
+                        &mwa_ctx,
+                        Some(&history),
+                        &vis_sel.coarse_chan_range,
+                    )
                     .expect("unable to initialize ms writer");
             });
             writer
@@ -1573,6 +1586,14 @@ mod tests {
         assert!(display.contains("Will not correct coarse pfb passband gains"));
         assert!(display.contains("Will flag with aoflagger"));
         assert!(display.contains("Will not correct geometry"));
+
+        let comment = birli_ctx.prep_ctx.as_comment();
+
+        assert!(!comment.contains("cable length corrections"));
+        assert!(!comment.contains("digital gains"));
+        assert!(!comment.contains("pfb gains"));
+        assert!(comment.contains("aoflagging with"));
+        assert!(!comment.contains("geometric corrections"));
     }
 
     /// Middle channel rounded-down is DC flagged when `flag_dc` is set.
@@ -2593,7 +2614,7 @@ mod tests_aoflagger {
             "--no-draw-progress",
             "--pfb-gains", "none",
             "--emulate-cotter",
-            "--no-flag-dc", 
+            "--no-flag-dc",
             "--flag-init", "0",
         ];
         args.extend_from_slice(&gpufits_paths);
@@ -2924,6 +2945,10 @@ mod tests_aoflagger {
         assert!(display.contains("Will correct digital gains"));
         assert!(display.contains("Will not flag with aoflagger"));
 
+        let comment = birli_ctx.prep_ctx.as_comment();
+        assert!(comment.contains("digital gain"));
+        assert!(!comment.contains("aoflag"));
+
         birli_ctx.run().unwrap();
 
         compare_ms_with_csv(
@@ -3011,6 +3036,9 @@ mod tests_aoflagger {
         let display = format!("{}", &birli_ctx);
         assert!(display.contains("Will correct coarse pfb passband gains"));
 
+        let comment = birli_ctx.prep_ctx.as_comment();
+        assert!(comment.contains("pfb gains"));
+
         birli_ctx.run().unwrap();
 
         compare_ms_with_csv(
@@ -3092,6 +3120,14 @@ mod tests_aoflagger {
         assert!(display.contains("Will not correct coarse pfb passband gains"));
         assert!(display.contains("Will flag with aoflagger"));
         assert!(display.contains("Will correct geometry"));
+
+        let comment = birli_ctx.prep_ctx.as_comment();
+
+        assert!(comment.contains("cable length corrections"));
+        assert!(!comment.contains("digital gains"));
+        assert!(!comment.contains("pfb gains"));
+        assert!(comment.contains("aoflagging with"));
+        assert!(comment.contains("geometric corrections"));
 
         birli_ctx.run().unwrap();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1392,19 +1392,25 @@ impl BirliContext {
 
             // only reallocate arrays if the chunk dimensions have changed.
             let chunk_dims = chunk_vis_sel.get_shape(fine_chans_per_coarse);
-            if jones_array.dim() != chunk_dims {
-                jones_array = chunk_vis_sel.allocate_jones(fine_chans_per_coarse)?;
-            }
-            if flag_array.dim() != chunk_dims {
-                flag_array = chunk_vis_sel.allocate_flags(fine_chans_per_coarse)?;
-            }
-            if weight_array.dim() != chunk_dims {
-                weight_array = chunk_vis_sel.allocate_weights(fine_chans_per_coarse)?;
-            }
+            let (mut jones_array, mut flag_array, mut weight_array) = if jones_array.dim()
+                == chunk_dims
+            {
+                (
+                    jones_array.view_mut(),
+                    flag_array.view_mut(),
+                    weight_array.view_mut(),
+                )
+            } else {
+                (
+                    jones_array.slice_mut(s![0..chunk_dims.0, 0..chunk_dims.1, 0..chunk_dims.2]),
+                    flag_array.slice_mut(s![0..chunk_dims.0, 0..chunk_dims.1, 0..chunk_dims.2]),
+                    weight_array.slice_mut(s![0..chunk_dims.0, 0..chunk_dims.1, 0..chunk_dims.2]),
+                )
+            };
 
             // populate flags
             flag_ctx.set_flags(
-                &mut flag_array,
+                flag_array.view_mut(),
                 &chunk_vis_sel.timestep_range,
                 &chunk_vis_sel.coarse_chan_range,
                 &chunk_vis_sel.get_ant_pairs(&corr_ctx.metafits_context),
@@ -1427,9 +1433,9 @@ impl BirliContext {
 
             prep_ctx.preprocess(
                 &corr_ctx,
-                &mut jones_array,
-                &mut weight_array,
-                &mut flag_array,
+                jones_array.view_mut(),
+                weight_array.view_mut(),
+                flag_array.view_mut(),
                 &mut durations,
                 &chunk_vis_sel,
             )?;
@@ -1440,7 +1446,7 @@ impl BirliContext {
                     durations,
                     "write",
                     flag_file_set
-                        .write_flag_array(&corr_ctx, &flag_array, &gpubox_ids)
+                        .write_flag_array(&corr_ctx, flag_array.view(), &gpubox_ids)
                         .expect("unable to write flags")
                 );
             }
@@ -1599,7 +1605,7 @@ mod tests {
         let mut flag_array = chunk_vis_sel.allocate_flags(fine_chans_per_coarse).unwrap();
         flag_ctx
             .set_flags(
-                &mut flag_array,
+                flag_array.view_mut(),
                 &chunk_vis_sel.timestep_range,
                 &chunk_vis_sel.coarse_chan_range,
                 &chunk_vis_sel.get_ant_pairs(&corr_ctx.metafits_context),

--- a/src/corrections.rs
+++ b/src/corrections.rs
@@ -41,7 +41,7 @@ use thiserror::Error;
 /// ];
 ///
 /// // Create an mwalib::CorrelatorContext for accessing visibilities.
-/// let corr_ctx = CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap();
+/// let corr_ctx = CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap();
 ///
 /// // Determine which timesteps and coarse channels we want to use
 /// let vis_sel = VisSelection::from_mwalib(&corr_ctx).unwrap();
@@ -177,7 +177,7 @@ pub fn correct_cable_lengths(
 /// ];
 ///
 /// // Create an mwalib::CorrelatorContext for accessing visibilities.
-/// let corr_ctx = CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap();
+/// let corr_ctx = CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap();
 ///
 /// // Determine which timesteps and coarse channels we want to use
 /// let mut vis_sel = VisSelection::from_mwalib(&corr_ctx).unwrap();
@@ -870,6 +870,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unnecessary_cast)]
     fn test_cable_length_corrections_ord() {
         let corr_ctx = get_mwa_ord_context();
         let vis_sel = VisSelection::from_mwalib(&corr_ctx).unwrap();
@@ -1050,6 +1051,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unnecessary_cast)]
     fn test_geometric_corrections_ord() {
         let corr_ctx = get_mwa_ord_context();
         let vis_sel = VisSelection::from_mwalib(&corr_ctx).unwrap();

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -6,7 +6,7 @@ use crate::{
     io::error::IOError,
     marlu::{
         mwalib::{CorrelatorContext, MWAVersion},
-        ndarray::{Array, Array3, ArrayView, Dimension},
+        ndarray::prelude::*,
     },
     BirliError, FlagFileSet,
 };
@@ -169,7 +169,7 @@ impl FlagContext {
     /// Can throw error if array is not the correct shape.
     pub fn set_flags(
         &self,
-        flag_array: &mut Array3<bool>,
+        mut flag_array: ArrayViewMut3<bool>,
         timestep_range: &Range<usize>,
         coarse_chan_range: &Range<usize>,
         ant_pairs: &[(usize, usize)],
@@ -355,8 +355,8 @@ pub fn flag_baseline_view_to_flagmask(
 /// flag_jones_array_existing(
 ///    &aoflagger,
 ///    &strategy_filename,
-///    &jones_array,
-///    &mut flag_array,
+///    jones_array.view(),
+///    flag_array.view_mut(),
 ///    true,
 ///    false,
 /// );
@@ -365,8 +365,8 @@ pub fn flag_baseline_view_to_flagmask(
 pub fn flag_jones_array_existing(
     aoflagger: &CxxAOFlagger,
     strategy_filename: &str,
-    jones_array: &Array3<Jones<f32>>,
-    flag_array: &mut Array3<bool>,
+    jones_array: ArrayView3<Jones<f32>>,
+    mut flag_array: ArrayViewMut3<bool>,
     re_apply_existing: bool,
     draw_progress: bool,
 ) {
@@ -437,14 +437,14 @@ pub fn flag_jones_array_existing(
 pub fn flag_jones_array(
     aoflagger: &CxxAOFlagger,
     strategy_filename: &str,
-    jones_array: &Array3<Jones<f32>>,
+    jones_array: ArrayView3<Jones<f32>>,
 ) -> Array3<bool> {
     let mut flag_array = Array3::from_elem(jones_array.dim(), false);
     flag_jones_array_existing(
         aoflagger,
         strategy_filename,
         jones_array,
-        &mut flag_array,
+        flag_array.view_mut(),
         false,
         false,
     );
@@ -495,7 +495,7 @@ pub fn flag_jones_array(
 /// let fine_chans_per_coarse = corr_ctx.metafits_context.num_corr_fine_chans_per_coarse;
 /// let mut flag_array = vis_sel.allocate_flags(fine_chans_per_coarse).unwrap();
 /// flag_ctx.set_flags(
-///     &mut flag_array,
+///     flag_array.view_mut(),
 ///     &vis_sel.timestep_range,
 ///     &vis_sel.coarse_chan_range,
 ///     &vis_sel.get_ant_pairs(&corr_ctx.metafits_context)
@@ -536,7 +536,7 @@ pub fn write_flags(
     );
 
     let mut flag_file_set = FlagFileSet::new(filename_template, &gpubox_ids, corr_ctx.mwa_version)?;
-    flag_file_set.write_flag_array(corr_ctx, flag_array, &gpubox_ids)?;
+    flag_file_set.write_flag_array(corr_ctx, flag_array.view(), &gpubox_ids)?;
 
     trace!("end write_flags");
     Ok(())
@@ -754,7 +754,7 @@ mod tests_aoflagger {
 
         let strategy_filename = aoflagger.FindStrategyFileGeneric(&String::from("minimal"));
 
-        let flag_array = flag_jones_array(&aoflagger, &strategy_filename, &jones_array);
+        let flag_array = flag_jones_array(&aoflagger, &strategy_filename, jones_array.view());
 
         assert!(!flag_array.get((0, 0, 0)).unwrap());
         assert!(!flag_array.get((noise_x, noise_y, 0)).unwrap());
@@ -807,8 +807,8 @@ mod tests_aoflagger {
         flag_jones_array_existing(
             &aoflagger,
             &strategy_filename,
-            &jones_array,
-            &mut existing_flag_array,
+            jones_array.view(),
+            existing_flag_array.view_mut(),
             true,
             false,
         );
@@ -837,7 +837,7 @@ mod tests_aoflagger {
         let mut flag_array = vis_sel.allocate_flags(fine_chans_per_coarse).unwrap();
         flag_ctx
             .set_flags(
-                &mut flag_array,
+                flag_array.view_mut(),
                 &vis_sel.timestep_range,
                 &vis_sel.coarse_chan_range,
                 &vis_sel.get_ant_pairs(&corr_ctx.metafits_context),
@@ -858,8 +858,8 @@ mod tests_aoflagger {
         flag_jones_array_existing(
             &aoflagger,
             strategy_filename,
-            &jones_array,
-            &mut flag_array,
+            jones_array.view(),
+            flag_array.view_mut(),
             true,
             false,
         );
@@ -893,7 +893,7 @@ mod tests_aoflagger {
         vis_sel.timestep_range = 0..1;
         assert!(matches!(
             flag_ctx.set_flags(
-                &mut flag_array,
+                flag_array.view_mut(),
                 &vis_sel.timestep_range,
                 &vis_sel.coarse_chan_range,
                 &vis_sel.get_ant_pairs(&corr_ctx.metafits_context),

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -90,7 +90,7 @@ impl FlagContext {
     /// ];
     ///
     /// // Create an mwalib::CorrelatorContext for accessing visibilities.
-    /// let corr_ctx = CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap();
+    /// let corr_ctx = CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap();
     /// let flag_ctx = FlagContext::from_mwalib(&corr_ctx);
     ///
     /// assert!(!flag_ctx.antenna_flags[0]);
@@ -330,7 +330,7 @@ pub fn flag_baseline_view_to_flagmask(
 /// ];
 ///
 /// // Create an mwalib::CorrelatorContext for accessing visibilities.
-/// let corr_ctx = CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap();
+/// let corr_ctx = CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap();
 ///
 /// // create a CxxAOFlagger object to perform AOFlagger operations
 /// let aoflagger = unsafe { cxx_aoflagger_new() };
@@ -483,7 +483,7 @@ pub fn flag_jones_array(
 /// let flag_template = tmp_dir.path().join("Flagfile%%%.mwaf");
 ///
 /// // Create an mwalib::CorrelatorContext for accessing visibilities.
-/// let corr_ctx = CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap();
+/// let corr_ctx = CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap();
 ///
 /// // Determine which timesteps and coarse channels we want to use
 /// let vis_sel = VisSelection::from_mwalib(&corr_ctx).unwrap();
@@ -718,7 +718,7 @@ mod tests_aoflagger {
             "tests/data/1196175296_mwa_ord/1196175296_20171201145440_gpubox02_00.fits",
             "tests/data/1196175296_mwa_ord/1196175296_20171201145540_gpubox02_01.fits",
         ];
-        CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap()
+        CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap()
     }
 
     /// Test that flags are sane when not using existing flags.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -12,13 +12,12 @@ use std::{
 };
 
 use log::trace;
-use marlu::{MwaObsContext, ObsContext, VisContext};
 
 use crate::{
     marlu::{
         io::{ms::MeasurementSetWriter, uvfits::UvfitsWriter, VisWritable},
         mwalib::{CorrelatorContext, MwalibError},
-        Jones, LatLngHeight, RADec,
+        Jones, LatLngHeight, MwaObsContext, ObsContext, RADec, VisContext,
     },
     ndarray::{ArrayView3, ArrayViewMut3},
 };
@@ -194,6 +193,7 @@ pub fn write_uvfits<T: AsRef<Path>>(
         Some(obs_ctx.array_pos),
         obs_ctx.phase_centre,
         obs_ctx.name.as_deref(),
+        None,
     )?;
 
     let ant_positions_geodetic: Vec<_> = obs_ctx.ant_positions_geodetic().collect();
@@ -327,7 +327,7 @@ pub fn write_ms<T: AsRef<Path>>(
         MeasurementSetWriter::new(path, obs_ctx.phase_centre, Some(obs_ctx.array_pos));
 
     ms_writer
-        .initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, coarse_chan_range)
+        .initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, None, coarse_chan_range)
         .unwrap();
 
     let ant_positions_geodetic: Vec<_> = obs_ctx.ant_positions_geodetic().collect();

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -398,7 +398,7 @@ mod tests_aoflagger {
         let mut flag_array = vis_sel.allocate_flags(fine_chans_per_coarse).unwrap();
         flag_ctx
             .set_flags(
-                &mut flag_array,
+                flag_array.view_mut(),
                 &vis_sel.timestep_range,
                 &vis_sel.coarse_chan_range,
                 &vis_sel.get_ant_pairs(&corr_ctx.metafits_context),
@@ -421,8 +421,8 @@ mod tests_aoflagger {
         flag_jones_array_existing(
             &aoflagger,
             strategy_filename,
-            &jones_array,
-            &mut flag_array,
+            jones_array.view(),
+            flag_array.view_mut(),
             true,
             false,
         );

--- a/src/io/mwaf.rs
+++ b/src/io/mwaf.rs
@@ -627,7 +627,7 @@ mod tests {
         let test_dir = Path::new("tests/data/1247842824_flags/");
 
         let context = CorrelatorContext::new(
-            &test_dir.join("1247842824.metafits"),
+            test_dir.join("1247842824.metafits"),
             &[test_dir.join("1247842824_20190722150008_gpubox01_00.fits")],
         )
         .unwrap();
@@ -725,7 +725,7 @@ mod tests {
         let test_dir = Path::new("tests/data/1247842824_flags/");
 
         let context = CorrelatorContext::new(
-            &test_dir.join("1247842824.metafits"),
+            test_dir.join("1247842824.metafits"),
             &[test_dir.join("1247842824_20190722150008_gpubox01_00.fits")],
         )
         .unwrap();

--- a/src/io/mwaf.rs
+++ b/src/io/mwaf.rs
@@ -12,10 +12,7 @@ use super::error::{
     IOError,
     IOError::{FitsIO, FitsOpen, InvalidFlagFilenameTemplate, InvalidGpuBox, MwafInconsistent},
 };
-use crate::{
-    error::BirliError,
-    ndarray::{Array3, Axis},
-};
+use crate::{error::BirliError, ndarray::prelude::*};
 use clap::crate_version;
 use fitsio::{
     hdu::FitsHdu,
@@ -282,7 +279,7 @@ impl FlagFileSet {
     pub fn write_flag_array(
         &mut self,
         context: &CorrelatorContext,
-        flag_array: &Array3<bool>,
+        flag_array: ArrayView3<bool>,
         gpubox_ids: &[usize],
     ) -> Result<(), IOError> {
         let flag_dims = flag_array.dim();
@@ -832,7 +829,7 @@ mod tests {
         )
         .unwrap();
         flag_file_set
-            .write_flag_array(&corr_ctx, &flag_array, &gpubox_ids)
+            .write_flag_array(&corr_ctx, flag_array.view(), &gpubox_ids)
             .unwrap();
         drop(flag_file_set);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! let fine_chans_per_coarse = corr_ctx.metafits_context.num_corr_fine_chans_per_coarse;
 //! let mut flag_array = vis_sel.allocate_flags(fine_chans_per_coarse).unwrap();
 //! flag_ctx.set_flags(
-//!     &mut flag_array,
+//!     flag_array.view_mut(),
 //!     &vis_sel.timestep_range,
 //!     &vis_sel.coarse_chan_range,
 //!     &vis_sel.get_ant_pairs(&corr_ctx.metafits_context)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! let uvfits_out = tmp_dir.path().join("1297526432.uvfits");
 //!
 //! // Create an mwalib::CorrelatorContext for accessing visibilities.
-//! let corr_ctx = CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap();
+//! let corr_ctx = CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap();
 //!
 //! // Determine which timesteps and coarse channels we want to use
 //! let vis_sel = VisSelection::from_mwalib(&corr_ctx).unwrap();

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -3,11 +3,7 @@ use crate::{
     calibration::apply_di_calsol,
     correct_cable_lengths, correct_geometry,
     corrections::{correct_coarse_passband_gains, correct_digital_gains, ScrunchType},
-    marlu::{
-        mwalib::CorrelatorContext,
-        ndarray::{Array2, Array3},
-        Jones, LatLngHeight, RADec,
-    },
+    marlu::{mwalib::CorrelatorContext, ndarray::prelude::*, Jones, LatLngHeight, RADec},
     with_increment_duration, BirliError, VisSelection,
 };
 use cfg_if::cfg_if;
@@ -129,9 +125,9 @@ impl PreprocessContext {
     pub fn preprocess(
         &self,
         corr_ctx: &CorrelatorContext,
-        jones_array: &mut Array3<Jones<f32>>,
-        weight_array: &mut Array3<f32>,
-        flag_array: &mut Array3<bool>,
+        mut jones_array: ArrayViewMut3<Jones<f32>>,
+        mut weight_array: ArrayViewMut3<f32>,
+        mut flag_array: ArrayViewMut3<bool>,
         durations: &mut HashMap<String, Duration>,
         vis_sel: &VisSelection,
     ) -> Result<(), BirliError> {
@@ -142,7 +138,7 @@ impl PreprocessContext {
                 "correct_cable",
                 correct_cable_lengths(
                     corr_ctx,
-                    jones_array,
+                    jones_array.view_mut(),
                     &vis_sel.coarse_chan_range,
                     self.draw_progress
                 )
@@ -158,7 +154,7 @@ impl PreprocessContext {
                 "correct_digital",
                 correct_digital_gains(
                     corr_ctx,
-                    jones_array,
+                    jones_array.view_mut(),
                     &vis_sel.coarse_chan_range,
                     &sel_ant_pairs,
                 )?
@@ -174,8 +170,8 @@ impl PreprocessContext {
                 durations,
                 "correct_passband",
                 correct_coarse_passband_gains(
-                    jones_array,
-                    weight_array,
+                    jones_array.view_mut(),
+                    weight_array.view_mut(),
                     passband_gains,
                     fine_chans_per_coarse,
                     &ScrunchType::from_mwa_version(corr_ctx.metafits_context.mwa_version.unwrap())?,
@@ -193,8 +189,8 @@ impl PreprocessContext {
                         flag_jones_array_existing(
                             &aoflagger,
                             strategy,
-                            jones_array,
-                            flag_array,
+                            jones_array.view(),
+                            flag_array.view_mut(),
                             true,
                             self.draw_progress,
                         )
@@ -210,7 +206,7 @@ impl PreprocessContext {
                 "correct_geom",
                 correct_geometry(
                     corr_ctx,
-                    jones_array,
+                    jones_array.view_mut(),
                     &vis_sel.timestep_range,
                     &vis_sel.coarse_chan_range,
                     Some(self.array_pos),
@@ -295,7 +291,7 @@ mod tests {
         let mut flag_array = vis_sel.allocate_flags(fine_chans_per_coarse).unwrap();
         flag_ctx
             .set_flags(
-                &mut flag_array,
+                flag_array.view_mut(),
                 &vis_sel.timestep_range,
                 &vis_sel.coarse_chan_range,
                 &vis_sel.get_ant_pairs(&corr_ctx.metafits_context),
@@ -320,9 +316,9 @@ mod tests {
         prep_ctx
             .preprocess(
                 &corr_ctx,
-                &mut jones_array,
-                &mut weight_array,
-                &mut flag_array,
+                jones_array.view_mut(),
+                weight_array.view_mut(),
+                flag_array.view_mut(),
                 &mut durations,
                 &vis_sel,
             )
@@ -397,9 +393,9 @@ mod tests {
         assert!(matches!(
             prep_ctx.preprocess(
                 &corr_ctx,
-                &mut jones_array,
-                &mut weight_array,
-                &mut flag_array,
+                jones_array.view_mut(),
+                weight_array.view_mut(),
+                flag_array.view_mut(),
                 &mut HashMap::new(),
                 &vis_sel
             ),
@@ -410,9 +406,9 @@ mod tests {
 
         let result = prep_ctx.preprocess(
             &corr_ctx,
-            &mut jones_array,
-            &mut weight_array,
-            &mut flag_array,
+            jones_array.view_mut(),
+            weight_array.view_mut(),
+            flag_array.view_mut(),
             &mut HashMap::new(),
             &vis_sel,
         );

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -108,6 +108,40 @@ impl Display for PreprocessContext {
 }
 
 impl PreprocessContext {
+    /// A one line description of the tasks preprocessing will do.
+    pub fn as_comment(&self) -> String {
+        [
+            if self.correct_cable_lengths {
+                Some("cable length corrections".to_string())
+            } else {
+                None
+            },
+            if self.correct_digital_gains {
+                Some("digital gains".to_string())
+            } else {
+                None
+            },
+            if self.passband_gains.is_some() {
+                Some("pfb gains".to_string())
+            } else {
+                None
+            },
+            #[cfg(feature = "aoflagger")]
+            self.aoflagger_strategy
+                .as_ref()
+                .map(|strategy| format!("aoflagging with {}", strategy)),
+            if self.correct_geometry {
+                Some("geometric corrections".to_string())
+            } else {
+                None
+            },
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<String>>()
+        .join(", ")
+    }
+
     /// Preprocess visibilities for a chunk of correlator data
     ///
     /// # Arguments

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -266,7 +266,7 @@ mod tests {
         let expected_csv_path =
             PathBuf::from("tests/data/1254670392_avg/1254670392.cotter.none.uvfits.csv");
 
-        let corr_ctx = CorrelatorContext::new(&metafits_path, &gpufits_paths)
+        let corr_ctx = CorrelatorContext::new(metafits_path, &gpufits_paths)
             .expect("unable to get mwalib context");
 
         let mut prep_ctx = PreprocessContext::default();
@@ -356,7 +356,7 @@ mod tests {
     pub fn test_handle_weird_mwa_versions() {
         let (metafits_path, gpufits_paths) = get_1254670392_avg_paths();
 
-        let mut corr_ctx = CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap();
+        let mut corr_ctx = CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap();
 
         let mut prep_ctx = PreprocessContext::default();
         let vis_sel = VisSelection::from_mwalib(&corr_ctx).unwrap();

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -74,12 +74,12 @@ pub const fn get_mwax_data_paths() -> (&'static str, [&'static str; 4]) {
 #[allow(dead_code)]
 pub(crate) fn get_1254670392_avg_context() -> CorrelatorContext {
     let (metafits_path, gpufits_paths) = get_1254670392_avg_paths();
-    CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap()
+    CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap()
 }
 
 pub fn get_mwax_context() -> CorrelatorContext {
     let (metafits_path, gpufits_paths) = get_mwax_data_paths();
-    CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap()
+    CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap()
 }
 
 pub fn get_mwa_ord_context() -> CorrelatorContext {
@@ -90,7 +90,7 @@ pub fn get_mwa_ord_context() -> CorrelatorContext {
         "tests/data/1196175296_mwa_ord/1196175296_20171201145440_gpubox02_00.fits",
         "tests/data/1196175296_mwa_ord/1196175296_20171201145540_gpubox02_01.fits",
     ];
-    CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap()
+    CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap()
 }
 
 /// Get a dummy MWA Ord `corr_ctx` with multiple holes in the data
@@ -110,7 +110,7 @@ pub fn get_mwa_ord_dodgy_context() -> CorrelatorContext {
         "tests/data/1196175296_mwa_ord/1196175296_20171201145440_gpubox02_00.fits",
         "tests/data/1196175296_mwa_ord/1196175296_20171201145540_gpubox02_01.fits",
     ];
-    CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap()
+    CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap()
 }
 
 /// Get a dummy MWA Ord `corr_ctx` with no overlapping timesteps
@@ -127,7 +127,7 @@ pub fn get_mwa_ord_no_overlap_context() -> CorrelatorContext {
         "tests/data/1196175296_mwa_ord/1196175296_20171201145440_gpubox01_00.fits",
         "tests/data/1196175296_mwa_ord/1196175296_20171201145540_gpubox02_01.fits",
     ];
-    CorrelatorContext::new(&metafits_path, &gpufits_paths).unwrap()
+    CorrelatorContext::new(metafits_path, &gpufits_paths).unwrap()
 }
 
 /// Get a dummy MWA Ord `corr_ctx` with no timesteps


### PR DESCRIPTION
- Fix unnecessary allocation for smaller visibility chunks
- use Marlu 0.7.0
- fixes https://github.com/MWATelescope/Birli/issues/67
- use rust version 1.60
- write `history` metadata in ms and uvfits
- use shlex for command line argument escaping
- use array views for flagging
- more precise corrections: fix #52
- remove .clone()s: fix #83
- use zip_eq over zip
- use latest ubuntu LTS in Dockerfile
- use full cargo bin in docker test, no separate nightly