### PR TITLE
Version info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,11 +1103,12 @@ dependencies = [
 
 [[package]]
 name = "marlu"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5624a18fc8cef0d3192003ccb215a9beeca3edb231ef0d8bac131e305ffa767a"
+checksum = "507de30748d54f0089596cd46baf056832f62f275b3d5b14f69819d45d8f82ff"
 dependencies = [
  "approx",
+ "built",
  "cfg-if",
  "crossbeam-channel",
  "crossbeam-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ indicatif = { version = "0.16", features = ["rayon"] }
 itertools = "0.10"
 lazy_static = "1.4.0"
 log = "0.4"
-marlu = "0.7.0"
+marlu = "0.7.2"
 prettytable-rs = "0.8.0"
 regex = "1.4"
 thiserror = "1.0"


### PR DESCRIPTION
clearer logging of versions and delays applied
    - instead of applied=true/false, show the type of delay
    - rename no_*_delay to *_delay_disabled
    - show library version info in logs