### PR TITLE
Don't print the debug representation of an error.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 <!-- markdownlint-disable=MD025 -->
 
+# Unreleased
+
+- 🙏 quality of life:
+  - report error messages properly, not as Rust-internal representation
+
 # Version 0.8.0 (2022-08-24)
 
 - ✨ new features:

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ where
         }
         Err(BirliError::ClapError(inner)) => inner.exit(),
         Err(e) => {
-            eprintln!("error parsing args: {:?}", e);
+            eprintln!("error parsing args: {}", e);
             return 1;
         }
     };


### PR DESCRIPTION
Before this commit, error messages were reported like:

error parsing args: MwalibError(Gpubox(LegacyNaxis2Mismatch { naxis2: 128, calculated_naxis2: 32, metafits_fine_chans_per_coarse: 32 }))

With this commit, it is now:

error parsing args: NAXIS2 in first gpubox image HDU 128 does not match expected value 32 (metafits fine chans per coarse [32])