### PR TITLE
Fix #140 - missing coarse channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,17 +199,17 @@ SELECTION:
         --no-sel-autos                [WIP] Deselect autocorrelations
         --no-sel-flagged-ants         [WIP] Deselect flagged antennas
         --sel-ants <ANTS>...          [WIP] Antenna to select
-        --sel-chan-ranges <RANGES>    [WIP] Select separate channel ranges
+        --sel-chan-ranges <RANGES>    Select separate channel ranges
         --sel-time <MIN> <MAX>        Timestep index range (inclusive) to select
 
 RESOURCE LIMITS:
-        --max-memory <GIBIBYTES>    [WIP] Estimate --time-chunk with <GIBIBYTES> GiB each chunk.
-        --time-chunk <STEPS>        [WIP] Process observation in chunks of <STEPS> timesteps.
+        --max-memory <GIBIBYTES>    Estimate --time-chunk with <GIBIBYTES> GiB each chunk.
+        --time-chunk <STEPS>        Process observation in chunks of <STEPS> timesteps.
 
 FLAGGING:
-        --flag-antennas <ANTS>...         [WIP] Flag antenna indices
-        --flag-autos                      [WIP] Flag auto correlations
-        --flag-coarse-chans <CHANS>...    [WIP] Flag additional coarse chan indices
+        --flag-antennas <ANTS>...         Flag antenna indices
+        --flag-autos                      Flag auto correlations
+        --flag-coarse-chans <CHANS>...    Flag additional coarse chan indices
         --flag-dc                         Force flagging of DC centre chans
         --flag-edge-chans <COUNT>         Flag <COUNT> fine chans on the ends of each coarse
         --flag-edge-width <KHZ>           Flag bandwidth [kHz] at the ends of each coarse chan
@@ -220,7 +220,7 @@ FLAGGING:
         --flag-init-steps <COUNT>         Flag <COUNT> steps after first common time
         --flag-times <STEPS>...           Flag additional time steps
         --no-flag-dc                      Do not flag DC centre chans
-        --no-flag-metafits                [WIP] Ignore antenna flags in metafits
+        --no-flag-metafits                Ignore antenna flags in metafits
 
 CORRECTION:
         --no-cable-delay           Do not perform cable length corrections
@@ -245,6 +245,7 @@ OUTPUT:
 AOFLAGGER:
         --aoflagger-strategy <PATH>    Strategy to use for RFI Flagging
         --no-rfi                       Do not perform RFI Flagging with aoflagger
+
 ```
 
 Note: the aoflagged options are only available when the aoflagger feature is enabled.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Adjust each coarse channel within a fine channel to correct for the shape of the
 
 When applying pfb gains to an observation that is not at the same resolution as the gains, the gains need to be averaged to fit the data, and the exact details of this averaging depends on the correlator type. For more dtails, see the mwa wiki on [averaging fine channels](https://wiki.mwatelescope.org/display/MP/MWA+Fine+Channel+Centre+Frequencies)
 
-### RFI Flagging.
+### RFI Flagging
 
 By default, Birli will flag the data using the default MWA strategy in AOFlagger. You can use the
 `--no-rfi` option to disable this, or the `--aoflagger-strategy` option to proived your own strategy

--- a/src/bin/birli.rs
+++ b/src/bin/birli.rs
@@ -30,7 +30,7 @@ where
             }
         }
         Err(e) => {
-            eprintln!("error parsing args: {e:?}");
+            eprintln!("error parsing args: {e}");
             return 1;
         }
     };
@@ -55,7 +55,7 @@ where
         }
         // TODO(Dev): different return codes for different errors
         Err(e) => {
-            eprintln!("preprocessing error: {e:?}");
+            eprintln!("preprocessing error: {e}");
             1
         }
     }

--- a/src/bin/birli.rs
+++ b/src/bin/birli.rs
@@ -172,6 +172,7 @@ mod tests {
             "--pfb-gains", "none",
             "--no-cable-delay",
             "--no-geometric-delay",
+            "--sel-chan-ranges", "1,2-3"
         ];
         args.extend_from_slice(&gpufits_paths);
 

--- a/src/bin/birli.rs
+++ b/src/bin/birli.rs
@@ -30,7 +30,7 @@ where
             }
         }
         Err(e) => {
-            eprintln!("error parsing args: {e}");
+            eprintln!("error parsing args: {e:?}");
             return 1;
         }
     };
@@ -55,7 +55,7 @@ where
         }
         // TODO(Dev): different return codes for different errors
         Err(e) => {
-            eprintln!("preprocessing error: {e}");
+            eprintln!("preprocessing error: {e:?}");
             1
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1327,9 +1327,7 @@ impl<'a> BirliContext<'a> {
             );
         }
 
-        for untested_option in &[
-            "put-untested-options-here"
-        ] {
+        for untested_option in &["put-untested-options-here"] {
             if matches.is_present(untested_option) {
                 warn!(
                     "option does not have full test coverage, use with caution: --{}",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -205,7 +205,7 @@ impl ChannelRanges {
 
     /// Create a new `ChannelRanges` object spanning all available channels in the metafits context
     pub fn all(context: &CorrelatorContext) -> Self {
-        let coarse_chan_indices = &context.common_coarse_chan_indices;
+        let coarse_chan_indices = &(0..context.num_coarse_chans).into_iter().collect_vec();
         // get the first value in the vector
         let mut range_start_idx = coarse_chan_indices[0];
         let mut range_end_idx = range_start_idx;
@@ -642,7 +642,6 @@ impl<'a> BirliContext<'a> {
                 arg!(--"no-draw-progress" "do not show progress bars"),
 
                 // selection options
-                // TODO: make this work the same way as rust ranges. start <= x < end
                 arg!(--"sel-time" "Timestep index range (inclusive) to select")
                     .help_heading("SELECTION")
                     .value_names(&["MIN", "MAX"])
@@ -656,16 +655,16 @@ impl<'a> BirliContext<'a> {
                 arg!(--"no-sel-autos" "[WIP] Deselect autocorrelations")
                     .help_heading("SELECTION"),
 
-                arg!(--"sel-chan-ranges" <RANGES> "[WIP] Select separate channel ranges")
+                arg!(--"sel-chan-ranges" <RANGES> "Select separate channel ranges")
                     .help_heading("SELECTION")
                     .required(false),
 
                 // resource limit options
-                arg!(--"time-chunk" <STEPS> "[WIP] Process observation in chunks of <STEPS> timesteps.")
+                arg!(--"time-chunk" <STEPS> "Process observation in chunks of <STEPS> timesteps.")
                     .help_heading("RESOURCE LIMITS")
                     .required(false)
                     .conflicts_with("max-memory"),
-                arg!(--"max-memory" <GIBIBYTES> "[WIP] Estimate --time-chunk with <GIBIBYTES> GiB each chunk.")
+                arg!(--"max-memory" <GIBIBYTES> "Estimate --time-chunk with <GIBIBYTES> GiB each chunk.")
                     .help_heading("RESOURCE LIMITS")
                     .required(false),
 
@@ -691,7 +690,7 @@ impl<'a> BirliContext<'a> {
                     .multiple_values(true)
                     .required(false),
                 // -> channels
-                arg!(--"flag-coarse-chans" <CHANS> ... "[WIP] Flag additional coarse chan indices")
+                arg!(--"flag-coarse-chans" <CHANS> ... "Flag additional coarse chan indices")
                     .help_heading("FLAGGING")
                     .multiple_values(true)
                     .required(false),
@@ -713,14 +712,14 @@ impl<'a> BirliContext<'a> {
                     .help_heading("FLAGGING")
                     .conflicts_with("flag-dc"),
                 // -> antennas
-                arg!(--"no-flag-metafits" "[WIP] Ignore antenna flags in metafits")
+                arg!(--"no-flag-metafits" "Ignore antenna flags in metafits")
                     .help_heading("FLAGGING"),
-                arg!(--"flag-antennas" <ANTS>... "[WIP] Flag antenna indices")
+                arg!(--"flag-antennas" <ANTS>... "Flag antenna indices")
                     .help_heading("FLAGGING")
                     .multiple_values(true)
                     .required(false),
                 // -> baselines
-                arg!(--"flag-autos" "[WIP] Flag auto correlations")
+                arg!(--"flag-autos" "Flag auto correlations")
                     .help_heading("FLAGGING"),
 
                 // corrections
@@ -1329,13 +1328,7 @@ impl<'a> BirliContext<'a> {
         }
 
         for untested_option in &[
-            "flag-coarse-chans",
-            "flag-fine-chans",
-            "flag-autos",
-            "no-flag-metafits",
-            "flag-antennas",
-            "time-chunk",
-            "max-memory",
+            "put-untested-options-here"
         ] {
             if matches.is_present(untested_option) {
                 warn!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2698,6 +2698,48 @@ mod argparse_tests {
         assert!(channel_range_sel.ranges[1].0 == 6);
         assert!(channel_range_sel.ranges[1].1 == 8);
     }
+
+    #[test]
+    fn test_handle_bad_chan_range_single() {
+        let (metafits_path, gpufits_paths) = get_1254670392_avg_paths();
+
+        #[rustfmt::skip]
+        let mut args = vec!["birli", "-m", metafits_path, "--sel-chan-ranges", "4,6-8,a", "--"];
+        args.extend_from_slice(&gpufits_paths);
+
+        assert!(matches!(
+            BirliContext::from_args(&args).err(),
+            Some(BirliError::CLIError(_))
+        ));
+    }
+
+    #[test]
+    fn test_handle_bad_ch_range_double() {
+        let (metafits_path, gpufits_paths) = get_1254670392_avg_paths();
+
+        #[rustfmt::skip]
+        let mut args = vec!["birli", "-m", metafits_path, "--sel-chan-ranges", "4,6-a", "--"];
+        args.extend_from_slice(&gpufits_paths);
+
+        assert!(matches!(
+            BirliContext::from_args(&args).err(),
+            Some(BirliError::CLIError(_))
+        ));
+    }
+
+    #[test]
+    fn test_handle_bad_ch_range_triple() {
+        let (metafits_path, gpufits_paths) = get_1254670392_avg_paths();
+
+        #[rustfmt::skip]
+        let mut args = vec!["birli", "-m", metafits_path, "--sel-chan-ranges", "4,6-7-8", "--"];
+        args.extend_from_slice(&gpufits_paths);
+
+        assert!(matches!(
+            BirliContext::from_args(&args).err(),
+            Some(BirliError::CLIError(_))
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ use crate::{
 use cfg_if::cfg_if;
 use clap::{arg, command, ErrorKind::ArgumentNotFound, PossibleValue, ValueHint::FilePath};
 use itertools::{izip, Itertools};
-use log::{debug, info, trace, warn};
+use log::{debug, info, trace};
 
 use mwalib::{
     built_info::PKG_VERSION as MWALIB_PKG_VERSION, fitsio_sys::CFITSIO_VERSION, CableDelaysApplied,
@@ -1327,14 +1327,14 @@ impl<'a> BirliContext<'a> {
             );
         }
 
-        for untested_option in &["put-untested-options-here"] {
-            if matches.is_present(untested_option) {
-                warn!(
-                    "option does not have full test coverage, use with caution: --{}",
-                    untested_option
-                );
-            }
-        }
+        // for untested_option in &["put-untested-options-here"] {
+        //     if matches.is_present(untested_option) {
+        //         warn!(
+        //             "option does not have full test coverage, use with caution: --{}",
+        //             untested_option
+        //         );
+        //     }
+        // }
 
         let io_ctx = Self::parse_io_matches(&matches);
         let corr_ctx = io_ctx.get_corr_ctx()?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ use crate::corrections::{DigitalGainCorrection, PassbandCorrection};
 #[derive(Error, Debug)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum CLIError {
-    #[error("Invalid Command Line Argument")]
+    #[error("Invalid Command Line Argument: option {option} expected {expected} but received {received}")]
     /// When a bad CLI argument is provided
     InvalidCommandLineArgument {
         /// The option for which the argument was provided
@@ -20,7 +20,7 @@ pub enum CLIError {
         /// The argument that was received instead
         received: String,
     },
-    #[error("Invalid range specifier")]
+    #[error("Invalid range specifier: {reason}")]
     /// When a bad range specifier is provided
     InvalidRangeSpecifier {
         /// Why the range is invalid
@@ -81,7 +81,7 @@ pub enum BirliError {
         need_gib: usize,
     },
 
-    #[error("Invalid MWA Version")]
+    #[error("Invalid MWA Version ({version}): {message}")]
     /// When a bad MWA Version is provided
     BadMWAVersion {
         /// The message to display

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,6 @@
 //! [`aoflagger::AOFlagger`]: http://www.andreoffringa.org/aoflagger/doxygen/classaoflagger_1_1AOFlagger.html
 
 #![warn(missing_docs)]
-#![warn(rustdoc::missing_doc_code_examples)]
 #![deny(clippy::all)]
 // //////// //
 // pedantic //


### PR DESCRIPTION
fixes #140 and #133
- by default, the coarse channels specified in the metafits are selected. 
- if scheduled range is contiguous, there will only be one file
- use --sel-chan-ranges to select individual coarse channels or ranges
- removed WIP from some arguments that had tests
- error messages are printed with dbg rather than fmt, which shows more information, like help message and line number.