### PR TITLE
van vleck warnings

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,6 +12,7 @@ name: Benchmarks
 
 jobs:
   test:
+    if: false  # <--- This disables the job
     name: Benchmarks
     runs-on: self-hosted
     steps:

--- a/.github/workflows/linux_test.yml
+++ b/.github/workflows/linux_test.yml
@@ -15,8 +15,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - "ubuntu-20.04"
           - "ubuntu-22.04"
+          - "ubuntu-22.04-arm"
+          - "ubuntu-24.04"
         feature_set:
           - "_no_flag"
           - ""

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "birli"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "aoflagger_sys",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "birli"
 description = "A preprocessing pipeline for the Murchison Widefield Array"
-version = "0.17.1"
+version = "0.18.0"
 readme = "README.md"
 homepage = "https://github.com/MWATelescope/Birli"
 repository = "https://github.com/MWATelescope/Birli"
@@ -101,7 +101,7 @@ console = { git = "https://github.com/console-rs/console", tag = "0.15.8" }
 flate2 = { git = "https://github.com/rust-lang/flate2-rs", tag = "1.0.35" }
 unicode-width = { git = "https://github.com/unicode-rs/unicode-width", tag = "v0.1.13" }
 cxx-build = { git = "https://github.com/dtolnay/cxx", tag = "1.0.124" }
-cxx = { git = "https://github.com/dtolnay/cxx", tag = "1.0.124" } 
+cxx = { git = "https://github.com/dtolnay/cxx", tag = "1.0.124" }
 half = { git = "https://github.com/VoidStarKat/half-rs", tag="v2.2.1" }
 # TODO: update to cxx 1.0.129 when MSRV >= 1.67
 url = { git = "https://github.com/servo/rust-url", tag = "v2.5.2" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,12 @@
 
 # Version 0.18.0 (unreleased)
 
+- 🙏 quality of life:
+  - `correct_van_vleck`, `correct_cable_lengths`, `correct_digital_gains` only applied to
+    unflagged visibilities, avoids printing hundreds of gigabytes of warnings.
 - 🏗 api changes:
+  - `correct_van_vleck`, `correct_cable_lengths` no longer have progress bars.
+  - `correct_cable_lengths` returns a `Result`.
   - `correct_van_vleck` now takes a `sample_scale` argument instead of a `CorrelatorContext`
   - `get_vv_sample_scale` added to public API.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 <!-- markdownlint-disable=MD025 -->
 
+# Version 0.18.0 (unreleased)
+
+- 🏗 api changes:
+  - `correct_van_vleck` now takes a `sample_scale` argument instead of a `CorrelatorContext`
+  - `get_vv_sample_scale` added to public API.
+
 # Version 0.17.1 (2025-04-11)
 
 - ➕ marlu 0.16.1

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,11 +3,12 @@
 # Version 0.18.0 (unreleased)
 
 - 🙏 quality of life:
-  - `correct_van_vleck`, `correct_cable_lengths`, `correct_digital_gains` only applied to
+  - `correct_van_vleck`, `correct_cable_lengths`, `correct_digital_gains`, `correct_coarse_passband_gains` only applied to
     unflagged visibilities, avoids printing hundreds of gigabytes of warnings.
 - 🏗 api changes:
   - `correct_van_vleck`, `correct_cable_lengths` no longer have progress bars.
   - `correct_cable_lengths` returns a `Result`.
+  - `correct_cable_lengths` now takes antenna index pairs instead of baseline indices.
   - `correct_van_vleck` now takes a `sample_scale` argument instead of a `CorrelatorContext`
   - `get_vv_sample_scale` added to public API.
 

--- a/benches/expensive_benches.rs
+++ b/benches/expensive_benches.rs
@@ -105,6 +105,7 @@ fn bench_correct_cable_lengths_mwax_half_1247842824(crt: &mut Criterion) {
     let fine_chans_per_coarse = corr_ctx.metafits_context.num_corr_fine_chans_per_coarse;
     let mut flag_array = vis_sel.allocate_flags(fine_chans_per_coarse).unwrap();
     let mut jones_array = vis_sel.allocate_jones(fine_chans_per_coarse).unwrap();
+    let ant_pairs = vis_sel.get_ant_pairs(&corr_ctx.metafits_context);
     read_mwalib(
         &vis_sel,
         &corr_ctx,
@@ -120,7 +121,7 @@ fn bench_correct_cable_lengths_mwax_half_1247842824(crt: &mut Criterion) {
                 black_box(&corr_ctx),
                 black_box(jones_array.view_mut()),
                 black_box(&vis_sel.coarse_chan_range),
-                black_box(&vis_sel.baseline_idxs),
+                black_box(&ant_pairs),
             )
         })
     });
@@ -133,6 +134,7 @@ fn bench_correct_cable_lengths_ord_half_1196175296(crt: &mut Criterion) {
     let fine_chans_per_coarse = corr_ctx.metafits_context.num_corr_fine_chans_per_coarse;
     let mut flag_array = vis_sel.allocate_flags(fine_chans_per_coarse).unwrap();
     let mut jones_array = vis_sel.allocate_jones(fine_chans_per_coarse).unwrap();
+    let ant_pairs = vis_sel.get_ant_pairs(&corr_ctx.metafits_context);
     read_mwalib(
         &vis_sel,
         &corr_ctx,
@@ -147,7 +149,7 @@ fn bench_correct_cable_lengths_ord_half_1196175296(crt: &mut Criterion) {
                 black_box(&corr_ctx),
                 black_box(jones_array.view_mut()),
                 black_box(&vis_sel.coarse_chan_range),
-                black_box(&vis_sel.baseline_idxs),
+                black_box(&ant_pairs),
             )
         })
     });

--- a/benches/expensive_benches.rs
+++ b/benches/expensive_benches.rs
@@ -121,7 +121,6 @@ fn bench_correct_cable_lengths_mwax_half_1247842824(crt: &mut Criterion) {
                 black_box(jones_array.view_mut()),
                 black_box(&vis_sel.coarse_chan_range),
                 black_box(&vis_sel.baseline_idxs),
-                false,
             )
         })
     });
@@ -149,7 +148,6 @@ fn bench_correct_cable_lengths_ord_half_1196175296(crt: &mut Criterion) {
                 black_box(jones_array.view_mut()),
                 black_box(&vis_sel.coarse_chan_range),
                 black_box(&vis_sel.baseline_idxs),
-                false,
             )
         })
     });

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -270,7 +270,6 @@ pub fn read_mwalib(
                         hdu_buffer.as_mut_slice(),
                     ) {
                         Ok(()) => {
-                            // arrays: [chan]
                             for (mut jones_array, baseline_idx) in izip!(
                                 jones_array.axis_iter_mut(Axis(1)),
                                 vis_sel.baseline_idxs.iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,7 @@ pub mod preprocessing;
 pub use preprocessing::PreprocessContext;
 
 pub mod van_vleck;
-pub use van_vleck::correct_van_vleck;
+pub use van_vleck::{correct_van_vleck, get_vv_sample_scale};
 
 cfg_if! {
     if #[cfg(feature = "cli")] {

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -296,7 +296,7 @@ impl PreprocessContext<'_> {
                                 corr_ctx,
                                 jones_chunk.view_mut(),
                                 &coarse_chan_range,
-                                &vis_sel.baseline_idxs,
+                                &sel_ant_pairs,
                             )?
                         );
                     }

--- a/src/van_vleck.rs
+++ b/src/van_vleck.rs
@@ -1464,6 +1464,7 @@ mod vv_cross_tests {
 
         let ant_pairs = vec![(0, 0), (0, 1), (1, 1)];
         let sample_scale = get_vv_sample_scale(&corr_ctx).unwrap();
+        assert_eq!(sample_scale, 1.0);
 
         correct_van_vleck(jones_array.view_mut(), &ant_pairs, &[], sample_scale).unwrap();
 

--- a/src/van_vleck.rs
+++ b/src/van_vleck.rs
@@ -1464,7 +1464,7 @@ mod vv_cross_tests {
 
         let ant_pairs = vec![(0, 0), (0, 1), (1, 1)];
         let sample_scale = get_vv_sample_scale(&corr_ctx).unwrap();
-        assert_eq!(sample_scale, 1.0);
+        assert_approx_eq!(f64, sample_scale, 1.0, epsilon=1e-9);
 
         correct_van_vleck(jones_array.view_mut(), &ant_pairs, &[], sample_scale).unwrap();
 


### PR DESCRIPTION
- `correct_van_vleck`, `correct_cable_lengths`, `correct_digital_gains`, `correct_coarse_passband_gains` only applied to unflagged visibilities, avoids printing hundreds of gigabytes of warnings.
- `correct_van_vleck`, `correct_cable_lengths` no longer have progress bars.
- `correct_cable_lengths` returns a `Result`.
- `correct_cable_lengths` now takes antenna index pairs instead of baseline indices.
- `correct_van_vleck` now takes a `sample_scale` argument instead of a `CorrelatorContext`
- `get_vv_sample_scale` added to public API.