### PR TITLE
fix #190 - Add NaN handling for calibration solutions

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -15,6 +15,8 @@ jobs:
         os:
           - macos-15-intel
           - macos-15
+          - macos-26-intel
+          - macos-26
     continue-on-error: true
     runs-on: "${{ matrix.os }}"
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,9 +274,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1416,15 +1416,15 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "marlu"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88646b41ebe8b57ee5b520cf8c1c8a62fe299547c6f8aafd27a95edbdd923aa"
+checksum = "a44f089b345c757217d3ec88068a4bdb57c0f0045124c25fe6f194f06bdc101f"
 dependencies = [
  "approx",
  "built",
@@ -1479,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "mwalib"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c3d7ed36fb84fc15ce7aff1fcf880e064c35b53ded0e95c972d1a2f23878fd"
+checksum = "80ea65cea2c4992b738a41b73e02f9470c5f78fcdbfbc5c20be468a2a6f965b9"
 dependencies = [
  "built",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "built"
@@ -1416,9 +1416,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "marlu"
@@ -2632,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 edition = "2021"
 # before updating me, grep for other instances of this version number
-rust-version = "1.85"
+rust-version = "1.85.0"
 license = "MPL-2.0"
 keywords = ["radioastronomy", "mwa", "astronomy", "aoflagger", "cotter"]
 categories = ["science", "parsing"]
@@ -45,7 +45,7 @@ indicatif = { version = "0.18", features = ["rayon"] }
 itertools = "0.14.0"
 lazy_static = "1.4.0"
 log = "0.4.0"
-marlu = "0.17.0"
+marlu = "0.17.1"
 regex = "1.12"
 thiserror = "2.0"
 errorfunctions = "0.2.0"
@@ -67,7 +67,7 @@ csv = "1.1"
 float-cmp = "0.10"
 glob = "0.3"
 lexical = "7.0"
-marlu = { version = "0.17.0", features = ["approx"] }
+marlu = { version = "0.17.1", features = ["approx"] }
 ndarray = { version = "0.16.1", features = ["approx"] }
 tempfile = "3.3"
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ descriptor for the speed which this library intends to deliver.
 
 ### Prerequisites
 
-- A Rust compiler with a version >= 1.65.0 - <https://www.rust-lang.org/tools/install>
+- A Rust compiler with a version >= 1.85.0 - <https://www.rust-lang.org/tools/install>
 - [AOFlagger](https://gitlab.com/aroffringa/aoflagger) >= 3.0
   (Ubuntu > 21.04: apt install aoflagger-dev)
 - [CFitsIO](https://heasarc.gsfc.nasa.gov/fitsio/) >= 3.49
@@ -428,7 +428,7 @@ USAGE:
 OPTIONS:
         --apply-di-cal <PATH>        Apply DI calibration solutions before averaging
         --dry-run                    Just print the summary and exit
-        --emulate-cotter             Use Cotter's array position, not MWAlib's
+        --emulate-cotter             Use Cotter's array position, not MWAlib's. Also, Birli will not flag NaNs when applying calibration solutions.
     -h, --help                       Print help information
         --no-draw-progress           do not show progress bars
         --phase-centre <RA> <DEC>    Override Phase centre from metafits (degrees)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 - 🐛 bug fixes:
   - Fix `--flag-edge-width` to be f32 instead of usize. Fixes #192
+  - Fix NaN handling for calibration solutions. Fixes #190
 - ➕ Bump to MSRV 1.85.
 - ➕ Update marlu to v0.17.0.
 - ➕ Upgrade clap v3 -> v4.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,10 +6,10 @@
   - Fix `--flag-edge-width` to be f32 instead of usize. Fixes #192
   - Fix NaN handling for calibration solutions. Fixes #190
     - `--emulate-cotter` will, in addition to using cotter's array positions, will also NOT flag NaN calibration solutions when passing `--apply-di-cal`.
-- ➕ Bump to MSRV 1.85.
-- ➕ Update marlu to v0.17.0.
+- ➕ Bump to MSRV 1.85.0.
+- ➕ Update marlu to v0.17.1.
 - ➕ Upgrade clap v3 -> v4.
-- ➕ Migrate macos CI to use macos-15 (arm64) and macos-15-intel (x64) and updated action versions.
+- ➕ Migrate macos CI to use macos-15 and macos-26 (arm64) and macos-15-intel / macos-26-intel (x64) and updated action versions.
 
 # Version 0.18.2 (2025-09-11)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,10 +1,11 @@
 <!-- markdownlint-disable=MD025 -->
 
-# Version 0.19.0 (2026-06-02)
+# Version 0.19.0 (2026-06-05)
 
 - 🐛 bug fixes:
   - Fix `--flag-edge-width` to be f32 instead of usize. Fixes #192
   - Fix NaN handling for calibration solutions. Fixes #190
+    - `--emulate-cotter` will, in addition to using cotter's array positions, will also NOT flag NaN calibration solutions when passing `--apply-di-cal`.
 - ➕ Bump to MSRV 1.85.
 - ➕ Update marlu to v0.17.0.
 - ➕ Upgrade clap v3 -> v4.

--- a/examples/preprocess.rs
+++ b/examples/preprocess.rs
@@ -88,6 +88,7 @@ fn main() {
             weight_array.view_mut(),
             flag_array.view_mut(),
             &vis_sel,
+            &[],
         )
         .unwrap();
 

--- a/examples/preprocess.rs
+++ b/examples/preprocess.rs
@@ -79,6 +79,7 @@ fn main() {
         calsols: None,
         #[cfg(feature = "aoflagger")]
         aoflagger_strategy: None,
+        emulate_cotter: args.contains(&"--emulate-cotter".to_string()),
     };
 
     prep_ctx

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -45,10 +45,7 @@ pub fn get_calsol_nan_flagged_tiles(calsols: ArrayView2<Jones<f64>>) -> Vec<bool
 }
 
 /// Flag antennas whose calibration solutions contain NaN in every channel.
-pub fn flag_antennas_with_nan_calsols(
-    antenna_flags: &mut [bool],
-    calsols: ArrayView2<Jones<f64>>,
-) {
+pub fn flag_antennas_with_nan_calsols(antenna_flags: &mut [bool], calsols: ArrayView2<Jones<f64>>) {
     for (tile_idx, tile_row) in calsols.axis_iter(Axis(0)).enumerate() {
         if tile_idx >= antenna_flags.len() {
             break;
@@ -84,6 +81,8 @@ pub fn apply_di_calsol(
     sel_baselines: &[(usize, usize)],
     // Per-tile flag mask indexed by antenna/tile number (e.g. from [`FlagContext::antenna_flags`])
     flagged_tiles: &[bool],
+    // If we are emulating cotter we don't flag NaNs
+    emulate_cotter: bool,
 ) -> Result<(), CalibrationError> {
     let di_dims = calsols.dim();
     let vis_dims = vis_array.dim();
@@ -127,10 +126,7 @@ pub fn apply_di_calsol(
             weight_array.axis_iter_mut(Axis(1)),
             flag_array.axis_iter_mut(Axis(1)),
         ) {
-            let baseline_tile_flagged = flagged_tiles
-                .get(ant1_idx)
-                .copied()
-                .unwrap_or(false)
+            let baseline_tile_flagged = flagged_tiles.get(ant1_idx).copied().unwrap_or(false)
                 || flagged_tiles.get(ant2_idx).copied().unwrap_or(false);
 
             // channel axis (chunked by channel_ratio)
@@ -147,7 +143,10 @@ pub fn apply_di_calsol(
                     weight_chunk.iter_mut(),
                     flag_chunk.iter_mut()
                 ) {
-                    if baseline_tile_flagged || sol1.any_nan() || sol2.any_nan() {
+                    // ignore nans if we are emulating cotter
+                    if baseline_tile_flagged
+                        || (!emulate_cotter && (sol1.any_nan() || sol2.any_nan()))
+                    {
                         *flag = true;
                         if *weight > 0. {
                             *weight = -*weight;
@@ -162,8 +161,8 @@ pub fn apply_di_calsol(
                     *vis = Jones::<f32>::from(sol1 * vis_f64 * sol2.h());
 
                     // if the data now contains a NaN, flag it
-                    // todo: not sure about this because Cotter doesn't do it.
-                    if vis.any_nan() {
+                    // Cotter doesn't do this, so skip when emulating it.
+                    if !emulate_cotter && vis.any_nan() {
                         *flag = true;
                         if *weight > 0. {
                             *weight = -*weight;
@@ -200,6 +199,7 @@ mod tests {
         });
         let mut flag_array = Array3::from_shape_fn(shape, |_| false);
         let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+        let emulate_cotter = false;
         apply_di_calsol(
             calsols.view(),
             vis_array.view_mut(),
@@ -207,6 +207,7 @@ mod tests {
             flag_array.view_mut(),
             &sel_baselines,
             &[],
+            emulate_cotter,
         )
         .unwrap();
 
@@ -238,6 +239,7 @@ mod tests {
         });
         let mut flag_array = Array3::from_shape_fn(shape, |_| false);
         let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+        let emulate_cotter = false;
         apply_di_calsol(
             calsols.view(),
             vis_array.view_mut(),
@@ -245,6 +247,7 @@ mod tests {
             flag_array.view_mut(),
             &sel_baselines,
             &[],
+            emulate_cotter,
         )
         .unwrap();
 
@@ -272,6 +275,7 @@ mod tests {
         });
         let mut flag_array = Array3::from_shape_fn(shape, |_| false);
         let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+        let emulate_cotter = false;
         apply_di_calsol(
             calsols.view(),
             vis_array.view_mut(),
@@ -279,6 +283,7 @@ mod tests {
             flag_array.view_mut(),
             &sel_baselines,
             &[],
+            emulate_cotter,
         )
         .unwrap();
 
@@ -313,6 +318,7 @@ mod tests {
         });
         let mut flag_array = Array3::from_shape_fn(shape, |_| false);
         let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+        let emulate_cotter = false;
         apply_di_calsol(
             calsols.view(),
             vis_array.view_mut(),
@@ -320,6 +326,7 @@ mod tests {
             flag_array.view_mut(),
             &sel_baselines,
             &[],
+            emulate_cotter,
         )
         .unwrap();
 
@@ -404,6 +411,7 @@ mod tests {
         ]];
         let mut flag_array = Array3::from_shape_fn(shape, |_| false);
         let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+        let emulate_cotter = false;
         apply_di_calsol(
             calsols.view(),
             vis_array.view_mut(),
@@ -411,6 +419,7 @@ mod tests {
             flag_array.view_mut(),
             &sel_baselines,
             &[],
+            emulate_cotter,
         )
         .unwrap();
 
@@ -437,6 +446,7 @@ mod tests {
         let orig_vis_array = vis_array.clone();
         let mut flag_array = Array3::from_shape_fn(shape, |_| false);
         let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+        let emulate_cotter = false;
 
         apply_di_calsol(
             calsols.view(),
@@ -445,6 +455,7 @@ mod tests {
             flag_array.view_mut(),
             &sel_baselines,
             &[false, true],
+            emulate_cotter,
         )
         .unwrap();
 
@@ -473,8 +484,7 @@ mod tests {
         let num_times = 1;
         let num_chans = 2;
 
-        let mut calsols =
-            Array2::from_shape_fn((2, num_chans), |(_, _)| Jones::identity() * 2.);
+        let mut calsols = Array2::from_shape_fn((2, num_chans), |(_, _)| Jones::identity() * 2.);
         calsols[(1, 1)] = Jones::nan();
 
         let shape = (num_times, num_chans, sel_baselines.len());
@@ -482,6 +492,7 @@ mod tests {
         let orig_vis_array = vis_array.clone();
         let mut flag_array = Array3::from_shape_fn(shape, |_| false);
         let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+        let emulate_cotter = false;
 
         apply_di_calsol(
             calsols.view(),
@@ -490,6 +501,7 @@ mod tests {
             flag_array.view_mut(),
             &sel_baselines,
             &[],
+            emulate_cotter,
         )
         .unwrap();
 
@@ -513,6 +525,7 @@ mod tests {
         let orig_vis_array = vis_array.clone();
         let mut flag_array = Array3::from_shape_fn(shape, |_| false);
         let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+        let emulate_cotter = false;
 
         apply_di_calsol(
             calsols.view(),
@@ -521,6 +534,7 @@ mod tests {
             flag_array.view_mut(),
             &sel_baselines,
             &[false, true],
+            emulate_cotter,
         )
         .unwrap();
 

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -31,12 +31,12 @@ pub enum CalibrationError {
     },
 }
 
-/// Returns whether every channel in a tile's calibration solution contains NaN.
+/// Returns whether every channel in a tile's calibration solution contains at least one NaN.
 fn tile_calsol_is_nan_flagged(tile_row: ArrayView1<Jones<f64>>) -> bool {
     !tile_row.is_empty() && tile_row.iter().all(|j| j.any_nan())
 }
 
-/// Get a per-tile mask for tiles whose calibration solutions are entirely NaN.
+/// Get a per-tile mask for tiles whose calibration solutions contain NaN in every channel.
 pub fn get_calsol_nan_flagged_tiles(calsols: ArrayView2<Jones<f64>>) -> Vec<bool> {
     calsols
         .axis_iter(Axis(0))
@@ -44,7 +44,7 @@ pub fn get_calsol_nan_flagged_tiles(calsols: ArrayView2<Jones<f64>>) -> Vec<bool
         .collect()
 }
 
-/// Flag antennas whose calibration solutions are entirely NaN.
+/// Flag antennas whose calibration solutions contain NaN in every channel.
 pub fn flag_antennas_with_nan_calsols(
     antenna_flags: &mut [bool],
     calsols: ArrayView2<Jones<f64>>,

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -1,6 +1,6 @@
 //! Calibrating visibilities.
 
-use crate::ndarray::{ArrayView2, ArrayViewMut3, Axis};
+use crate::ndarray::{ArrayView1, ArrayView2, ArrayViewMut3, Axis};
 use itertools::izip;
 use marlu::Jones;
 use thiserror::Error;
@@ -31,8 +31,39 @@ pub enum CalibrationError {
     },
 }
 
+/// Returns whether every channel in a tile's calibration solution contains NaN.
+fn tile_calsol_is_nan_flagged(tile_row: ArrayView1<Jones<f64>>) -> bool {
+    !tile_row.is_empty() && tile_row.iter().all(|j| j.any_nan())
+}
+
+/// Get a per-tile mask for tiles whose calibration solutions are entirely NaN.
+pub fn get_calsol_nan_flagged_tiles(calsols: ArrayView2<Jones<f64>>) -> Vec<bool> {
+    calsols
+        .axis_iter(Axis(0))
+        .map(tile_calsol_is_nan_flagged)
+        .collect()
+}
+
+/// Flag antennas whose calibration solutions are entirely NaN.
+pub fn flag_antennas_with_nan_calsols(
+    antenna_flags: &mut [bool],
+    calsols: ArrayView2<Jones<f64>>,
+) {
+    for (tile_idx, tile_row) in calsols.axis_iter(Axis(0)).enumerate() {
+        if tile_idx >= antenna_flags.len() {
+            break;
+        }
+        if tile_calsol_is_nan_flagged(tile_row) {
+            antenna_flags[tile_idx] = true;
+        }
+    }
+}
+
 /// apply a direction independent calibration solution for a single timeblock to the given
 /// visibility data
+///
+/// Baselines involving a tile marked in `flagged_tiles`, or a calibration solution containing
+/// NaN, are flagged and calibration is not applied.
 ///
 /// # Errors
 ///
@@ -51,6 +82,8 @@ pub fn apply_di_calsol(
     mut flag_array: ArrayViewMut3<bool>,
     // The tile index pairs for each selected baseline
     sel_baselines: &[(usize, usize)],
+    // Per-tile flag mask indexed by antenna/tile number (e.g. from [`FlagContext::antenna_flags`])
+    flagged_tiles: &[bool],
 ) -> Result<(), CalibrationError> {
     let di_dims = calsols.dim();
     let vis_dims = vis_array.dim();
@@ -94,6 +127,12 @@ pub fn apply_di_calsol(
             weight_array.axis_iter_mut(Axis(1)),
             flag_array.axis_iter_mut(Axis(1)),
         ) {
+            let baseline_tile_flagged = flagged_tiles
+                .get(ant1_idx)
+                .copied()
+                .unwrap_or(false)
+                || flagged_tiles.get(ant2_idx).copied().unwrap_or(false);
+
             // channel axis (chunked by channel_ratio)
             for (&sol1, &sol2, mut vis_chunk, mut weight_chunk, mut flag_chunk) in izip!(
                 calsols.index_axis(Axis(0), ant1_idx),
@@ -108,6 +147,14 @@ pub fn apply_di_calsol(
                     weight_chunk.iter_mut(),
                     flag_chunk.iter_mut()
                 ) {
+                    if baseline_tile_flagged || sol1.any_nan() || sol2.any_nan() {
+                        *flag = true;
+                        if *weight > 0. {
+                            *weight = -*weight;
+                        }
+                        continue;
+                    }
+
                     // promote
                     let vis_f64 = Jones::<f64>::from(*vis);
 
@@ -159,6 +206,7 @@ mod tests {
             weight_array.view_mut(),
             flag_array.view_mut(),
             &sel_baselines,
+            &[],
         )
         .unwrap();
 
@@ -196,6 +244,7 @@ mod tests {
             weight_array.view_mut(),
             flag_array.view_mut(),
             &sel_baselines,
+            &[],
         )
         .unwrap();
 
@@ -229,6 +278,7 @@ mod tests {
             weight_array.view_mut(),
             flag_array.view_mut(),
             &sel_baselines,
+            &[],
         )
         .unwrap();
 
@@ -269,6 +319,7 @@ mod tests {
             weight_array.view_mut(),
             flag_array.view_mut(),
             &sel_baselines,
+            &[],
         )
         .unwrap();
 
@@ -359,10 +410,144 @@ mod tests {
             weight_array.view_mut(),
             flag_array.view_mut(),
             &sel_baselines,
+            &[],
         )
         .unwrap();
 
         compare_jones!(vis_array[(0, 0, 0)], exp_vis_array[(0, 0, 0)]);
         compare_jones!(vis_array[(0, 1, 0)], exp_vis_array[(0, 1, 0)]);
+    }
+
+    /// Tiles with all-NaN calibration solutions flag all baselines involving that tile.
+    #[test]
+    fn test_apply_calsols_nan_flagged_tile() {
+        let sel_baselines = vec![(0, 0), (0, 1), (1, 1)];
+        let num_times = 1;
+        let num_chans = 2;
+
+        let mut calsols = Array2::from_shape_fn((2, num_chans), |(_, _)| Jones::identity());
+        for chan in 0..num_chans {
+            calsols[(1, chan)] = Jones::nan();
+        }
+
+        let shape = (num_times, num_chans, sel_baselines.len());
+        let mut vis_array = Array3::from_shape_fn(shape, |(_, _, bl)| {
+            Jones::<f32>::identity() * (bl + 1) as f32
+        });
+        let orig_vis_array = vis_array.clone();
+        let mut flag_array = Array3::from_shape_fn(shape, |_| false);
+        let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+
+        apply_di_calsol(
+            calsols.view(),
+            vis_array.view_mut(),
+            weight_array.view_mut(),
+            flag_array.view_mut(),
+            &sel_baselines,
+            &[false, true],
+        )
+        .unwrap();
+
+        // auto on unflagged tile 0 is calibrated
+        compare_jones!(
+            vis_array[(0, 0, 0)],
+            calsols[(0, 0)] * (Jones::<f64>::identity() * 1.) * calsols[(0, 0)].h()
+        );
+        assert!(!flag_array[(0, 0, 0)]);
+
+        // baselines involving all-NaN tile 1 are flagged without modifying visibilities
+        for chan in 0..num_chans {
+            assert!(flag_array[(0, chan, 1)]);
+            assert!(flag_array[(0, chan, 2)]);
+            assert_eq!(weight_array[(0, chan, 1)], -1.);
+            assert_eq!(weight_array[(0, chan, 2)], -1.);
+            compare_jones!(vis_array[(0, chan, 1)], orig_vis_array[(0, chan, 1)]);
+            compare_jones!(vis_array[(0, chan, 2)], orig_vis_array[(0, chan, 2)]);
+        }
+    }
+
+    /// Partially NaN calibration solutions flag only affected channels.
+    #[test]
+    fn test_apply_calsols_partial_nan_channel() {
+        let sel_baselines = vec![(0, 1)];
+        let num_times = 1;
+        let num_chans = 2;
+
+        let mut calsols =
+            Array2::from_shape_fn((2, num_chans), |(_, _)| Jones::identity() * 2.);
+        calsols[(1, 1)] = Jones::nan();
+
+        let shape = (num_times, num_chans, sel_baselines.len());
+        let mut vis_array = Array3::from_shape_fn(shape, |_| Jones::<f32>::identity());
+        let orig_vis_array = vis_array.clone();
+        let mut flag_array = Array3::from_shape_fn(shape, |_| false);
+        let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+
+        apply_di_calsol(
+            calsols.view(),
+            vis_array.view_mut(),
+            weight_array.view_mut(),
+            flag_array.view_mut(),
+            &sel_baselines,
+            &[],
+        )
+        .unwrap();
+
+        assert!(!flag_array[(0, 0, 0)]);
+        assert!(flag_array[(0, 1, 0)]);
+        compare_jones!(vis_array[(0, 0, 0)], orig_vis_array[(0, 0, 0)] * 4.);
+        compare_jones!(vis_array[(0, 1, 0)], orig_vis_array[(0, 1, 0)]);
+    }
+
+    /// User-flagged tiles skip calibration even when solutions are valid.
+    #[test]
+    fn test_apply_calsols_user_flagged_tile() {
+        let sel_baselines = vec![(0, 0), (0, 1)];
+        let num_times = 1;
+
+        let calsols = Array2::from_shape_fn((2, 1), |(_, _)| Jones::identity() * 2.);
+        let shape = (num_times, calsols.dim().1, sel_baselines.len());
+        let mut vis_array = Array3::from_shape_fn(shape, |(_, _, bl)| {
+            Jones::<f32>::identity() * (bl + 1) as f32
+        });
+        let orig_vis_array = vis_array.clone();
+        let mut flag_array = Array3::from_shape_fn(shape, |_| false);
+        let mut weight_array = Array3::from_shape_fn(shape, |_| 1_f32);
+
+        apply_di_calsol(
+            calsols.view(),
+            vis_array.view_mut(),
+            weight_array.view_mut(),
+            flag_array.view_mut(),
+            &sel_baselines,
+            &[false, true],
+        )
+        .unwrap();
+
+        compare_jones!(
+            vis_array[(0, 0, 0)],
+            calsols[(0, 0)] * (Jones::<f64>::identity() * 1.) * calsols[(0, 0)].h()
+        );
+        assert!(!flag_array[(0, 0, 0)]);
+
+        assert!(flag_array[(0, 0, 1)]);
+        assert_eq!(weight_array[(0, 0, 1)], -1.);
+        compare_jones!(vis_array[(0, 0, 1)], orig_vis_array[(0, 0, 1)]);
+    }
+
+    #[test]
+    fn test_get_calsol_nan_flagged_tiles() {
+        let mut calsols = Array2::from_shape_fn((3, 2), |(_, _)| Jones::identity());
+        calsols[(1, 0)] = Jones::nan();
+        calsols[(1, 1)] = Jones::nan();
+        calsols[(2, 0)] = Jones::from([
+            Complex::new(f64::NAN, 0.),
+            Complex::new(0., 0.),
+            Complex::new(0., 0.),
+            Complex::new(0., 0.),
+        ]);
+
+        let flagged = get_calsol_nan_flagged_tiles(calsols.view());
+        assert_eq!(flagged, vec![false, true, false]);
     }
 }

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -66,6 +66,7 @@ pub fn flag_antennas_with_nan_calsols(antenna_flags: &mut [bool], calsols: Array
 ///
 /// calsols should have the same number of channels as `vis_array`, `flag_array`, `weight_array` etc.
 ///
+#[allow(clippy::too_many_arguments)]
 pub fn apply_di_calsol(
     // a two dimensional array of jones matrix calibration solutions with
     // dimensions `[tile][channel]`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,7 @@ use mwalib::{
 use prettytable::{format as prettyformat, row, table};
 
 use crate::{
+    calibration::flag_antennas_with_nan_calsols,
     error::{
         BirliError::{self, BadMWAVersion, DryRun},
         CLIError::{InvalidCommandLineArgument, InvalidRangeSpecifier},
@@ -1572,7 +1573,6 @@ impl<'a> BirliContext<'a> {
         let Self {
             corr_ctx,
             vis_sel,
-            flag_ctx,
             io_ctx,
             avg_time,
             avg_freq,
@@ -1580,6 +1580,7 @@ impl<'a> BirliContext<'a> {
             ..
         } = self;
         let mut prep_ctx = self.prep_ctx.clone();
+        let mut flag_ctx = self.flag_ctx.clone();
 
         // ////////// //
         // Prepare IO //
@@ -1657,6 +1658,9 @@ impl<'a> BirliContext<'a> {
         } else {
             None
         };
+        if let Some(ref calsols) = prep_ctx.calsols {
+            flag_antennas_with_nan_calsols(&mut flag_ctx.antenna_flags, calsols.view());
+        }
 
         let args_strings = std::env::args().collect_vec();
         let cmd_line = shlex::try_join(args_strings.iter().map(String::as_str)).unwrap();
@@ -1845,6 +1849,7 @@ impl<'a> BirliContext<'a> {
                 weight_array.view_mut(),
                 flag_array.view_mut(),
                 &chunk_vis_sel,
+                &flag_ctx.antenna_flags,
             )?;
 
             // output flags (before averaging)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -663,7 +663,7 @@ impl<'a> BirliContext<'a> {
                 .required(false),
             arg!(--"pointing-centre" "Use pointing instead phase centre")
                 .conflicts_with("phase-centre"),
-            arg!(--"emulate-cotter" "Use Cotter's array position, not MWAlib's"),
+            arg!(--"emulate-cotter" "Use Cotter's array position, not MWAlib's. Also, Birli will not flag NaNs when applying calibration solutions."),
             arg!(--"dry-run" "Just print the summary and exit"),
             arg!(--"no-draw-progress" "do not show progress bars"),
 
@@ -1316,6 +1316,7 @@ impl<'a> BirliContext<'a> {
     ) -> Result<PreprocessContext<'a>, BirliError> {
         let mut prep_ctx = PreprocessContext {
             draw_progress: !matches.get_flag("no-draw-progress"),
+            emulate_cotter: matches.get_flag("emulate-cotter"),
             ..PreprocessContext::default()
         };
         let CorrelatorContext {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -26,7 +26,7 @@ cfg_if! {
 }
 
 /// Which timesteps, channels and baselines are flagged in a given observation
-#[derive(Builder, Debug, Default)]
+#[derive(Builder, Clone, Debug, Default)]
 pub struct FlagContext {
     // TODO: remove _flags suffix
     /// Which mwalib timestep indices are flagged

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -182,6 +182,7 @@ impl PreprocessContext<'_> {
         mut weight_array: ArrayViewMut3<f32>,
         mut flag_array: ArrayViewMut3<bool>,
         vis_sel: &VisSelection,
+        flagged_tiles: &[bool],
     ) -> Result<(), BirliError> {
         let sel_ant_pairs = vis_sel.get_ant_pairs(&corr_ctx.metafits_context);
         let fine_chans_per_coarse = corr_ctx.metafits_context.num_corr_fine_chans_per_coarse;
@@ -353,6 +354,7 @@ impl PreprocessContext<'_> {
                     weight_array.view_mut(),
                     flag_array.view_mut(),
                     &sel_ant_pairs,
+                    flagged_tiles,
                 )?
             );
         }
@@ -445,6 +447,7 @@ mod tests {
                 weight_array.view_mut(),
                 flag_array.view_mut(),
                 &vis_sel,
+                &[],
             )
             .unwrap();
 
@@ -522,6 +525,7 @@ mod tests {
                 weight_array.view_mut(),
                 flag_array.view_mut(),
                 &vis_sel,
+                &[],
             )
             .is_ok());
 
@@ -533,6 +537,7 @@ mod tests {
             weight_array.view_mut(),
             flag_array.view_mut(),
             &vis_sel,
+            &[],
         );
 
         assert!(matches!(result, Err(BirliError::BadMWAVersion { .. })));
@@ -635,6 +640,7 @@ mod tests {
                 weight_array.view_mut(),
                 flag_array.view_mut(),
                 &vis_sel,
+                &[],
             )
             .unwrap();
 

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -60,6 +60,10 @@ pub struct PreprocessContext<'a> {
     /// Whether to draw progress bars
     #[builder(default = "true")]
     pub draw_progress: bool,
+
+    /// Should we emulate cotter OR flag NaNs when applying cal solutions
+    #[builder(default = "false")]
+    pub emulate_cotter: bool,
 }
 
 impl Display for PreprocessContext<'_> {
@@ -355,6 +359,7 @@ impl PreprocessContext<'_> {
                     flag_array.view_mut(),
                     &sel_ant_pairs,
                     flagged_tiles,
+                    self.emulate_cotter
                 )?
             );
         }


### PR DESCRIPTION
- Introduced functions to flag antennas with NaN calibration solutions.
- Updated `apply_di_calsol` to incorporate flags for NaN solutions.
- Modified preprocessing and CLI to utilize new flagging functionality.
- Added tests to validate behavior with NaN calibration solutions.